### PR TITLE
28 game grid rework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CXX := clang++
 
-CXXFLAGS := -std=c++17 -Wall -Wextra -Werror -pthread -MMD -MP -g
+CXXFLAGS := -std=c++17 -Wall -Wextra -Werror -pthread -MMD -MP -g -gdwarf-4
 
 LDFLAGS := -pthread
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXX := g++
+CXX := clang
 
 CXXFLAGS := -std=c++17 -Wall -Wextra -Werror -pthread -MMD -MP -g
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXX := clang
+CXX := clang++
 
 CXXFLAGS := -std=c++17 -Wall -Wextra -Werror -pthread -MMD -MP -g
 

--- a/inc/action/Action.h
+++ b/inc/action/Action.h
@@ -11,7 +11,6 @@ class MoveAction;
 class TransferMoneyAction;
 class BuildAction;
 class AttackAction;
-class Game;
 
 #include "json.hpp"
 using json = nlohmann::ordered_json;
@@ -35,7 +34,7 @@ public:
 
 	static std::vector<Action *> parseActions(json msg);
 
-	virtual bool execute(Game *game, Core *core) = 0;
+	virtual bool execute(Core *core) = 0;
 	virtual void decodeJSON(json msg) = 0;
 	virtual json encodeJSON() = 0;
 
@@ -50,6 +49,5 @@ protected:
 #include "TransferMoneyAction.h"
 #include "BuildAction.h"
 #include "AttackAction.h"
-#include "Game.h"
 
 #endif // ACTION_H

--- a/inc/action/AttackAction.h
+++ b/inc/action/AttackAction.h
@@ -8,6 +8,9 @@
 #include "Money.h"
 #include "Bomb.h"
 
+#include "Resource.h"
+#include "Board.h"
+
 class Unit;
 
 #include "json.hpp"
@@ -21,7 +24,7 @@ class AttackAction : public Action
 		Position getTargetPos() const { return target_pos_; }
 		unsigned int getDamage() const { return damage_; }
 
-		bool execute(Game *game, Core * core);
+		bool execute(Core * core);
 		void decodeJSON(json msg);
 		json encodeJSON();
 	
@@ -30,7 +33,7 @@ class AttackAction : public Action
 		Position target_pos_;
 		unsigned int damage_;
 
-		bool attackObj(Object *obj, Unit * unit, Game *game);
+		bool attackObj(Object *obj, Unit * unit);
 };
 
 #endif // ATTACK_ACTION_H

--- a/inc/action/BuildAction.h
+++ b/inc/action/BuildAction.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "Action.h"
+#include "Wall.h"
 
 #include "json.hpp"
 using json = nlohmann::ordered_json;
@@ -13,7 +14,7 @@ class BuildAction : public Action
 	public:
 		BuildAction(json msg);
 
-		bool execute(Game *game, Core * core);
+		bool execute(Core * core);
 		void decodeJSON(json msg);
 		json encodeJSON();
 

--- a/inc/action/CreateAction.h
+++ b/inc/action/CreateAction.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "Action.h"
+#include "Utils.h"
 
 #include "json.hpp"
 using json = nlohmann::ordered_json;
@@ -15,7 +16,7 @@ public:
 
 	unsigned int getUnitType() const { return unit_type_; }
 
-	bool execute(Game *game, Core *core);
+	bool execute(Core *core);
 	void decodeJSON(json msg);
 	json encodeJSON();
 

--- a/inc/action/MoveAction.h
+++ b/inc/action/MoveAction.h
@@ -20,7 +20,7 @@ class MoveAction : public Action
 		unsigned int getUnitId() const { return unit_id_; }
 		Position getTarget() const { return target_; }
 
-		bool execute(Game *game, Core * core);
+		bool execute(Core * core);
 		void decodeJSON(json msg);
 		json encodeJSON();
 	

--- a/inc/action/TransferMoneyAction.h
+++ b/inc/action/TransferMoneyAction.h
@@ -14,7 +14,7 @@ class TransferMoneyAction : public Action
 	public:
 		TransferMoneyAction(json msg);
 
-		bool execute(Game *game, Core * core);
+		bool execute(Core * core);
 		void decodeJSON(json msg);
 		json encodeJSON();
 	
@@ -23,7 +23,7 @@ class TransferMoneyAction : public Action
 		Position target_;
 		unsigned int amount_;
 
-		bool dropMoney(Game *game, Core * core, Object *srcObj);
+		bool dropMoney(Core * core, Object *srcObj);
 };
 
 #endif // TRANSFER_MONEY_ACTION_H

--- a/inc/config/Config.h
+++ b/inc/config/Config.h
@@ -75,21 +75,21 @@ struct UnitConfig
 
 class Config
 {
-public:
-	static GameConfig &getInstance();
-	static json encodeConfig();
+	public:
+		static GameConfig &instance();
+		static json encodeConfig();
 
-	static Position &getCorePosition(unsigned int teamId);
-	static UnitConfig &getUnitConfig(unsigned int typeId);
+		static Position &getCorePosition(unsigned int teamId);
+		static UnitConfig &getUnitConfig(unsigned int typeId);
 
-	static void setConfigFilePath(const std::string &path)
-	{
-		configFilePath = path;
-	}
-	static std::string getConfigFilePath() { return configFilePath; }
+		static void setConfigFilePath(const std::string &path)
+		{
+			configFilePath = path;
+		}
+		static std::string getConfigFilePath() { return configFilePath; }
 
-private:
-	static std::string configFilePath;
+	private:
+		static std::string configFilePath;
 };
 
 #endif // CONFIG_H

--- a/inc/config/worldgen/DistancedResourceWorldGenerator.h
+++ b/inc/config/worldgen/DistancedResourceWorldGenerator.h
@@ -2,19 +2,21 @@
 #define DISTANCED_RESOURCE_WORLD_GENERATOR_H
 
 #include "WorldGenerator.h"
+#include "Board.h"
+#include "Money.h"
+#include "Resource.h"
+#include "Logger.h"
 
 #include <random>
 #include <time.h>
 #include <string.h>
-
-#include "Game.h"
 
 class DistancedResourceWorldGenerator : public WorldGenerator
 {
 	public:
 		DistancedResourceWorldGenerator();
 
-		void generateWorld(Game * game);
+		void generateWorld();
 
 	private:
 		std::default_random_engine eng_ = std::default_random_engine(time(nullptr));

--- a/inc/config/worldgen/JigsawWorldGenerator/JigsawWorldGenerator.h
+++ b/inc/config/worldgen/JigsawWorldGenerator/JigsawWorldGenerator.h
@@ -1,13 +1,20 @@
 #pragma once
 
-#include "Game.h"
 #include "Config.h"
 #include "MapTemplate.h"
 #include "WorldGenerator.h"
+#include "Logger.h"
+#include "Object.h"
+#include "Wall.h"
+#include "Resource.h"
+#include "Money.h"
+#include "Board.h"
+#include "Visualizer.h"
 
 #include <vector>
 #include <string>
 #include <filesystem>
+#include <queue>
 #include <cstdlib>
 #include <climits>
 #include <algorithm>
@@ -25,7 +32,7 @@ class JigsawWorldGenerator : public WorldGenerator {
 	public:
 		JigsawWorldGenerator(unsigned int seed = 0);
 
-		void generateWorld(Game* game);
+		void generateWorld();
 
 	private:
 		std::vector<MapTemplate> templates_;
@@ -34,11 +41,11 @@ class JigsawWorldGenerator : public WorldGenerator {
 
 		void loadTemplates();
 
-		bool tryPlaceTemplate(Game* game, const MapTemplate &temp, int posX, int posY, bool force);
-		bool canPlaceTemplate(Game* game, const MapTemplate &temp, int posX, int posY);
+		bool tryPlaceTemplate(const MapTemplate &temp, int posX, int posY, bool force);
+		bool canPlaceTemplate(const MapTemplate &temp, int posX, int posY);
 
-		void balanceObjectType(Game* game, ObjectType type, int amount);
-		void clearPathBetweenCores(Game* game);
-		void placeWalls(Game* game);
-		void mirrorWorld(Game* game);
+		void balanceObjectType(ObjectType type, int amount);
+		void clearPathBetweenCores();
+		void placeWalls();
+		void mirrorWorld();
 };

--- a/inc/config/worldgen/WorldGenerator.h
+++ b/inc/config/worldgen/WorldGenerator.h
@@ -4,20 +4,15 @@
 #include <vector>
 #include <memory>
 
-#include "Object.h"
-#include "Resource.h"
-#include "Wall.h"
-#include "Game.h"
-
 class Game;
 
 class WorldGenerator
 {
 	public:
-		WorldGenerator();
+		WorldGenerator() = default;
 		virtual ~WorldGenerator() = default;
 		
-		virtual void generateWorld(Game * game) = 0;
+		virtual void generateWorld() = 0;
 };
 
 #endif // WORLD_GENERATOR_H

--- a/inc/game/Board.h
+++ b/inc/game/Board.h
@@ -8,6 +8,9 @@
 #include "Core.h"
 
 // TODO: instead of clone, use builtin copy constructor functionality
+// TODO: remove auto usage until very necessary, its just unclear
+// TODO: can you somehow configure the board iterator to skip stuff conditionally, to only loop over objects with certain type for example?
+// TODO: rework getnextobjectid to not have to be called manually from outside the function all the time
 
 class Board
 {

--- a/inc/game/Board.h
+++ b/inc/game/Board.h
@@ -6,8 +6,9 @@
 
 #include "Object.h"
 #include "Core.h"
+#include "Config.h"
 
-// TODO: instead of clone, use builtin copy constructor functionality
+// TODO: instead of local object-specific position data, make board a singleton and access position data from there
 // TODO: remove auto usage until very necessary, its just unclear
 // TODO: can you somehow configure the board iterator to skip stuff conditionally, to only loop over objects with certain type for example?
 // TODO: rework getnextobjectid to not have to be called manually from outside the function all the time
@@ -17,6 +18,11 @@ class Board
 	public:
 		Board(unsigned int grid_width, unsigned int grid_height);
 		~Board() = default;
+
+		static Board& instance() {
+			static Board _instance(Config::instance().width, Config::instance().height);
+			return _instance;
+		}
 
 		template <typename T>
 		bool			addObject(const T &object, bool force = false)

--- a/inc/game/Board.h
+++ b/inc/game/Board.h
@@ -19,7 +19,7 @@ class Board
 		~Board() = default;
 
 		template <typename T>
-		bool			addObject(const Object & object, bool force = false)
+		bool			addObject(const T &object, bool force = false)
 		{
 			static_assert(std::is_base_of<Object, T>::value, "T must be a subclass of Object");
 			unsigned int vecPos = gridPosToVecPos(object.getPosition());

--- a/inc/game/Board.h
+++ b/inc/game/Board.h
@@ -25,7 +25,7 @@ class Board
 		{
 			static_assert(std::is_base_of<Object, T>::value, "T must be a subclass of Object");
 			unsigned int vecPos = gridPosToVecPos(pos);
-			if (vecPos < 0 || (objects_[vecPos] != nullptr && !force))
+			if (vecPos > grid_height_ * grid_width_ || (objects_[vecPos] != nullptr && !force))
 				return false;
 			objects_[vecPos] = std::make_unique<T>(object);
 			return true;

--- a/inc/game/Board.h
+++ b/inc/game/Board.h
@@ -3,12 +3,12 @@
 
 #include <vector>
 #include <iterator>
+#include <limits>
 
 #include "Object.h"
 #include "Core.h"
 #include "Config.h"
 
-// TODO: instead of local object-specific position data, make board a singleton and access position data from there
 // TODO: remove auto usage until very necessary, its just unclear
 // TODO: can you somehow configure the board iterator to skip stuff conditionally, to only loop over objects with certain type for example?
 // TODO: rework getnextobjectid to not have to be called manually from outside the function all the time
@@ -25,10 +25,10 @@ class Board
 		}
 
 		template <typename T>
-		bool			addObject(const T &object, bool force = false)
+		bool			addObject(const T &object, Position pos, bool force = false)
 		{
 			static_assert(std::is_base_of<Object, T>::value, "T must be a subclass of Object");
-			unsigned int vecPos = gridPosToVecPos(object.getPosition());
+			unsigned int vecPos = gridPosToVecPos(pos);
 			if (vecPos < 0 || (objects_[vecPos] != nullptr && !force))
 				return false;
 			objects_[vecPos] = std::make_unique<T>(object);
@@ -40,6 +40,7 @@ class Board
 		Object			*getObjectById(unsigned int id) const;
 		Object			*getObjectAtPos(const Position & pos) const;
 		Core			*getCoreByTeamId(unsigned int team_id) const;
+		Position		getObjectPositionById(unsigned int id) const;
 
 		bool			moveObjectById(unsigned int id, const Position & newPos);
 

--- a/inc/game/Board.h
+++ b/inc/game/Board.h
@@ -9,10 +9,6 @@
 #include "Core.h"
 #include "Config.h"
 
-// TODO: remove auto usage until very necessary, its just unclear
-// TODO: can you somehow configure the board iterator to skip stuff conditionally, to only loop over objects with certain type for example?
-// TODO: rework getnextobjectid to not have to be called manually from outside the function all the time
-
 class Board
 {
 	public:

--- a/inc/game/Board.h
+++ b/inc/game/Board.h
@@ -1,0 +1,75 @@
+#ifndef BOARD_H
+#define BOARD_H
+
+#include <vector>
+#include <iterator>
+
+#include "Object.h"
+#include "Core.h"
+
+// TODO: instead of clone, use builtin copy constructor functionality
+
+class Board
+{
+	public:
+		Board(unsigned int grid_width, unsigned int grid_height);
+		~Board() = default;
+
+		bool			addObject(const Object & object, bool force = false);
+		bool			removeObjectById(unsigned int id);
+		bool			removeObjectAtPos(const Position & pos);
+
+		Object			*getObjectById(unsigned int id) const;
+		Object			*getObjectAtPos(const Position & pos) const;
+		Core			*getCoreByTeamId(unsigned int team_id) const;
+
+		Position		vecPosToGridPos(unsigned int vecPos) const;
+		unsigned int	gridPosToVecPos(const Position & gridPos) const;
+
+		unsigned int	getNextObjectId() { return next_object_id_++; }
+
+	private:
+		std::vector<std::unique_ptr<Object>> objects_; // [ 5 | 3] is at index grid_width * 5 + 3
+
+		unsigned int grid_width_;
+		unsigned int grid_height_;
+
+		unsigned int next_object_id_ = 0;
+
+
+	// @brief Board Iterator that only exposes valid objects
+	class Iterator
+	{
+		using VecIt = std::vector<std::unique_ptr<Object>>::iterator;
+		VecIt current_, end_;
+
+		void advance_to_valid()
+		{
+			while (current_ != end_ && !*current_)
+				++current_;
+		}
+
+	public:
+		Iterator(VecIt begin, VecIt end)
+			: current_{begin}, end_{end} { advance_to_valid(); }
+
+		Object &operator*() const { return *current_->get(); }
+		Object *operator->() const { return  current_->get(); }
+
+		Iterator& operator++() {
+			++current_;
+			advance_to_valid();
+			return *this;
+		}
+
+		bool operator!=(const Iterator &other) const {
+			return current_ != other.current_;
+		}
+	};
+
+	public:
+		Iterator begin()	{ return {objects_.begin(), objects_.end()}; }
+		Iterator end()		{ return {objects_.end(), objects_.end()}; }
+};
+
+#endif // BOARD_H

--- a/inc/game/Board.h
+++ b/inc/game/Board.h
@@ -35,6 +35,8 @@ class Board
 		Object			*getObjectAtPos(const Position & pos) const;
 		Core			*getCoreByTeamId(unsigned int team_id) const;
 
+		bool			moveObjectById(unsigned int id, const Position & newPos);
+
 		Position		vecPosToGridPos(unsigned int vecPos) const;
 		unsigned int	gridPosToVecPos(const Position & gridPos) const;
 

--- a/inc/game/Board.h
+++ b/inc/game/Board.h
@@ -19,7 +19,15 @@ class Board
 		~Board() = default;
 
 		template <typename T>
-		bool			addObject(const Object & object, bool force = false);
+		bool			addObject(const Object & object, bool force = false)
+		{
+			static_assert(std::is_base_of<Object, T>::value, "T must be a subclass of Object");
+			unsigned int vecPos = gridPosToVecPos(object.getPosition());
+			if (vecPos < 0 || (objects_[vecPos] != nullptr && !force))
+				return false;
+			objects_[vecPos] = std::make_unique<T>(object);
+			return true;
+		}
 		bool			removeObjectById(unsigned int id);
 		bool			removeObjectAtPos(const Position & pos);
 

--- a/inc/game/Board.h
+++ b/inc/game/Board.h
@@ -18,6 +18,7 @@ class Board
 		Board(unsigned int grid_width, unsigned int grid_height);
 		~Board() = default;
 
+		template <typename T>
 		bool			addObject(const Object & object, bool force = false);
 		bool			removeObjectById(unsigned int id);
 		bool			removeObjectAtPos(const Position & pos);

--- a/inc/game/Game.h
+++ b/inc/game/Game.h
@@ -32,14 +32,14 @@ class Game
 
 		void visualizeGameState(unsigned long long tick);
 
+		Board board_;
+
 	private:
 		void tick(unsigned long long tick);
 
 		json encodeState(std::vector<std::pair<Action *, Core &>> actions, unsigned long long tick);
 		void sendState(std::vector<std::pair<Action *, Core &>> actions, unsigned long long tick);
 		void sendConfig();
-
-		Board board_;
 
 		unsigned int teamCount_;
 		unsigned int nextObjectId_;

--- a/inc/game/Game.h
+++ b/inc/game/Game.h
@@ -14,6 +14,7 @@
 #include "Action.h"
 #include "Utils.h"
 #include "ReplayEncoder.h"
+#include "Board.h"
 
 #include "json.hpp"
 using json = nlohmann::ordered_json;
@@ -29,26 +30,19 @@ class Game
 
 		void run();
 
-		Core * getCore(unsigned int teamId);
-		std::vector<Core> getCores();
-		Object * getObject(unsigned int id);
-		std::vector<std::unique_ptr<Object>> & getObjects() { return objects_; }
-
-		Object * getObjectAtPos(Position pos);
-		void removeObjectById(unsigned int id);
-
-		unsigned int getNextObjectId() { return nextObjectId_++; }
-
 		void visualizeGameState(unsigned long long tick);
 
 	private:
 		void tick(unsigned long long tick);
+
+		json encodeState(std::vector<std::pair<Action *, Core &>> actions, unsigned long long tick);
 		void sendState(std::vector<std::pair<Action *, Core &>> actions, unsigned long long tick);
 		void sendConfig();
 
+		Board board_;
+
 		unsigned int teamCount_;
 		unsigned int nextObjectId_;
-		std::vector<std::unique_ptr<Object>> objects_;
 		std::vector<Bridge*> bridges_;
 
 		ReplayEncoder replayEncoder_;

--- a/inc/game/Game.h
+++ b/inc/game/Game.h
@@ -15,6 +15,7 @@
 #include "Utils.h"
 #include "ReplayEncoder.h"
 #include "Board.h"
+#include "Visualizer.h"
 
 #include "json.hpp"
 using json = nlohmann::ordered_json;
@@ -29,10 +30,6 @@ class Game
 		void addBridge(Bridge* bridge);
 
 		void run();
-
-		void visualizeGameState(unsigned long long tick);
-
-		Board board_;
 
 	private:
 		void tick(unsigned long long tick);

--- a/inc/game/Visualizer.h
+++ b/inc/game/Visualizer.h
@@ -1,0 +1,16 @@
+#ifndef VISUALIZER_H
+#define VISUALIZER_H
+
+#include "Config.h"
+#include "Board.h"
+#include "Object.h"
+#include "Core.h"
+#include "Unit.h"
+
+class Visualizer
+{
+	public:
+		static void visualizeGameState(unsigned long long tick);
+};
+
+#endif // VISUALIZER_H

--- a/inc/object/Bomb.h
+++ b/inc/object/Bomb.h
@@ -9,7 +9,7 @@
 class Bomb : public Object
 {
 	public:
-		Bomb(unsigned int id, Position pos);
+		Bomb(unsigned int id);
 		Bomb(const Bomb &other)
 			: Object(other), countdown_(other.countdown_) {}
 

--- a/inc/object/Bomb.h
+++ b/inc/object/Bomb.h
@@ -8,14 +8,14 @@ class Bomb : public Object
 {
 	public:
 		Bomb(unsigned int id, Position pos);
+		Bomb(const Bomb &other)
+			: Object(other), countdown_(other.countdown_) {}
 
 		void tick(unsigned long long tickCount, Game * game);
 
-		Position getPos() const { return pos_; }
 		unsigned int getCountdown() const { return countdown_; }
 
 	private:
-		Position pos_;
 		unsigned int countdown_ = 0; // Countdown for the bomb to explode
 };
 

--- a/inc/object/Bomb.h
+++ b/inc/object/Bomb.h
@@ -3,6 +3,8 @@
 
 #include "Object.h"
 #include "Common.h"
+#include "Config.h"
+#include "Board.h"
 
 class Bomb : public Object
 {
@@ -11,7 +13,7 @@ class Bomb : public Object
 		Bomb(const Bomb &other)
 			: Object(other), countdown_(other.countdown_) {}
 
-		void tick(unsigned long long tickCount, Game * game);
+		void tick(unsigned long long tickCount);
 
 		unsigned int getCountdown() const { return countdown_; }
 

--- a/inc/object/Bomb.h
+++ b/inc/object/Bomb.h
@@ -10,7 +10,6 @@ class Bomb : public Object
 		Bomb(unsigned int id, Position pos);
 
 		void tick(unsigned long long tickCount, Game * game);
-		std::unique_ptr<Object> & clone(Position newPos, Game * game) const;
 
 		Position getPos() const { return pos_; }
 		unsigned int getCountdown() const { return countdown_; }

--- a/inc/object/Core.h
+++ b/inc/object/Core.h
@@ -8,7 +8,7 @@
 class Core : public Object
 {
 	public:
-		Core(unsigned int id, unsigned int teamId, Position pos);
+		Core(unsigned int id, unsigned int teamId);
 		Core (const Core & other)
 			: Object(other), balance_(other.balance_), team_id_(other.team_id_) {}
 		Core& operator=(const Core& other) {

--- a/inc/object/Core.h
+++ b/inc/object/Core.h
@@ -3,6 +3,7 @@
 
 #include "Object.h"
 #include "Common.h"
+#include "Config.h"
 
 class Core : public Object
 {
@@ -19,7 +20,7 @@ class Core : public Object
 			return *this;
 		}
 
-		void tick(unsigned long long tickCount, Game * game);
+		void tick(unsigned long long tickCount);
 
 		unsigned int getBalance() const { return balance_; }
 		void setBalance(unsigned int balance) { balance_ = balance; }

--- a/inc/object/Core.h
+++ b/inc/object/Core.h
@@ -8,6 +8,16 @@ class Core : public Object
 {
 	public:
 		Core(unsigned int id, unsigned int teamId, Position pos);
+		Core (const Core & other)
+			: Object(other), balance_(other.balance_), team_id_(other.team_id_) {}
+		Core& operator=(const Core& other) {
+			if (this == &other)
+				return *this;
+			Object::operator=(other);
+			balance_ = other.balance_;
+			team_id_ = other.team_id_;
+			return *this;
+		}
 
 		void tick(unsigned long long tickCount, Game * game);
 

--- a/inc/object/Core.h
+++ b/inc/object/Core.h
@@ -10,7 +10,6 @@ class Core : public Object
 		Core(unsigned int id, unsigned int teamId, Position pos);
 
 		void tick(unsigned long long tickCount, Game * game);
-		std::unique_ptr<Object> & clone(Position newPos, Game * game) const;
 
 		unsigned int getBalance() const { return balance_; }
 		void setBalance(unsigned int balance) { balance_ = balance; }

--- a/inc/object/Money.h
+++ b/inc/object/Money.h
@@ -4,6 +4,7 @@
 #include "Object.h"
 #include "Common.h"
 #include "Unit.h"
+#include "Config.h"
 
 #include <cmath>
 
@@ -15,7 +16,7 @@ class Money : public Object
 		Money(const Money & other)
 			: Object(other), balance_(other.balance_) {}
 
-		void tick(unsigned long long tickCount, Game * game);
+		void tick(unsigned long long tickCount);
 
 		unsigned int getBalance() const { return balance_; }
 

--- a/inc/object/Money.h
+++ b/inc/object/Money.h
@@ -14,7 +14,6 @@ class Money : public Object
 		Money(unsigned int id, Position pos, unsigned int balance);
 
 		void tick(unsigned long long tickCount, Game * game);
-		std::unique_ptr<Object> & clone(Position newPos, Game * game) const;
 
 		unsigned int getBalance() const { return balance_; }
 

--- a/inc/object/Money.h
+++ b/inc/object/Money.h
@@ -12,6 +12,8 @@ class Money : public Object
 	public:
 		Money(unsigned int id, Position pos);
 		Money(unsigned int id, Position pos, unsigned int balance);
+		Money(const Money & other)
+			: Object(other), balance_(other.balance_) {}
 
 		void tick(unsigned long long tickCount, Game * game);
 

--- a/inc/object/Money.h
+++ b/inc/object/Money.h
@@ -11,8 +11,8 @@
 class Money : public Object
 {
 	public:
-		Money(unsigned int id, Position pos);
-		Money(unsigned int id, Position pos, unsigned int balance);
+		Money(unsigned int id);
+		Money(unsigned int id, unsigned int balance);
 		Money(const Money & other)
 			: Object(other), balance_(other.balance_) {}
 

--- a/inc/object/Object.h
+++ b/inc/object/Object.h
@@ -23,6 +23,8 @@ class Object
 	public:
 		Object(unsigned int id, Position pos, int hp, ObjectType type)
 			: id_(id), position_(pos), hp_(hp), type_(type) {}
+		Object(const Object &other)
+			: id_(other.id_), position_(other.position_), hp_(other.hp_), type_(other.type_) {}
 		virtual ~Object() {}
 
 		virtual void tick(unsigned long long tickCount, Game * game) = 0;

--- a/inc/object/Object.h
+++ b/inc/object/Object.h
@@ -26,7 +26,6 @@ class Object
 		virtual ~Object() {}
 
 		virtual void tick(unsigned long long tickCount, Game * game) = 0;
-		virtual std::unique_ptr<Object> & clone(Position newPos, Game * game) const = 0;
 
 		unsigned int getId() const { return id_; };
 		Position getPosition() const { return position_; };

--- a/inc/object/Object.h
+++ b/inc/object/Object.h
@@ -17,26 +17,22 @@ enum class ObjectType
 class Object
 {
 	public:
-		Object(unsigned int id, Position pos, int hp, ObjectType type)
-			: id_(id), position_(pos), hp_(hp), type_(type) {}
+		Object(unsigned int id, int hp, ObjectType type)
+			: id_(id), hp_(hp), type_(type) {}
 		Object(const Object &other)
-			: id_(other.id_), position_(other.position_), hp_(other.hp_), type_(other.type_) {}
+			: id_(other.id_), hp_(other.hp_), type_(other.type_) {}
 		virtual ~Object() {}
 
 		virtual void tick(unsigned long long tickCount) = 0;
 
 		unsigned int getId() const { return id_; };
-		Position getPosition() const { return position_; };
 		int getHP() const { return hp_; };
 		ObjectType getType() const { return type_; };
 
-		void setPosition(Position pos) { position_ = pos; };
 		void setHP(int hp) { hp_ = hp; };
 
 	protected:
-	// when adding more object fields, add them to deep copy functionality in object children
 		unsigned int id_;
-		Position position_;
 		int hp_;
 
 		ObjectType type_;

--- a/inc/object/Object.h
+++ b/inc/object/Object.h
@@ -2,10 +2,6 @@
 #define OBJECT_H
 
 #include "Common.h"
-#include "Config.h"
-#include "Logger.h"
-
-class Game;
 
 // must be in same order as t_obj_type in connection lib
 enum class ObjectType
@@ -27,7 +23,7 @@ class Object
 			: id_(other.id_), position_(other.position_), hp_(other.hp_), type_(other.type_) {}
 		virtual ~Object() {}
 
-		virtual void tick(unsigned long long tickCount, Game * game) = 0;
+		virtual void tick(unsigned long long tickCount) = 0;
 
 		unsigned int getId() const { return id_; };
 		Position getPosition() const { return position_; };

--- a/inc/object/Resource.h
+++ b/inc/object/Resource.h
@@ -14,7 +14,6 @@ class Resource : public Object
 		Resource(unsigned int id, Position pos, unsigned int balance);
 
 		void tick(unsigned long long tickCount, Game * game);
-		std::unique_ptr<Object> & clone(Position newPos, Game * game) const;
 		void getMined(Unit * miner);
 
 		unsigned int getBalance() const { return balance_; }

--- a/inc/object/Resource.h
+++ b/inc/object/Resource.h
@@ -12,6 +12,8 @@ class Resource : public Object
 	public:
 		Resource(unsigned int id, Position pos);
 		Resource(unsigned int id, Position pos, unsigned int balance);
+		Resource(const Resource &other)
+			: Object(other), balance_(other.balance_) {}
 
 		void tick(unsigned long long tickCount, Game * game);
 		void getMined(Unit * miner);

--- a/inc/object/Resource.h
+++ b/inc/object/Resource.h
@@ -11,8 +11,8 @@
 class Resource : public Object
 {
 	public:
-		Resource(unsigned int id, Position pos);
-		Resource(unsigned int id, Position pos, unsigned int balance);
+		Resource(unsigned int id);
+		Resource(unsigned int id, unsigned int balance);
 		Resource(const Resource &other)
 			: Object(other), balance_(other.balance_) {}
 

--- a/inc/object/Resource.h
+++ b/inc/object/Resource.h
@@ -4,6 +4,7 @@
 #include "Object.h"
 #include "Common.h"
 #include "Unit.h"
+#include "Config.h"
 
 #include <cmath>
 
@@ -15,7 +16,7 @@ class Resource : public Object
 		Resource(const Resource &other)
 			: Object(other), balance_(other.balance_) {}
 
-		void tick(unsigned long long tickCount, Game * game);
+		void tick(unsigned long long tickCount);
 		void getMined(Unit * miner);
 
 		unsigned int getBalance() const { return balance_; }

--- a/inc/object/Unit.h
+++ b/inc/object/Unit.h
@@ -8,6 +8,9 @@ class Unit : public Object
 {
 public:
 	Unit(unsigned int id, unsigned int teamId, Position pos, unsigned int unit_type);
+	Unit(const Unit &other)
+		: Object(other), unit_type_(other.unit_type_), team_id_(other.team_id_),
+		  balance_(other.balance_), next_move_opp_(other.next_move_opp_) {}
 
 	void tick(unsigned long long tickCount, Game *game);
 

--- a/inc/object/Unit.h
+++ b/inc/object/Unit.h
@@ -3,6 +3,7 @@
 
 #include "Object.h"
 #include "Common.h"
+#include "Config.h"
 
 class Unit : public Object
 {
@@ -12,7 +13,7 @@ public:
 		: Object(other), unit_type_(other.unit_type_), team_id_(other.team_id_),
 		  balance_(other.balance_), next_move_opp_(other.next_move_opp_) {}
 
-	void tick(unsigned long long tickCount, Game *game);
+	void tick(unsigned long long tickCount);
 
 	unsigned int getUnitType() const { return unit_type_; }
 	unsigned int getTeamId() const { return team_id_; }

--- a/inc/object/Unit.h
+++ b/inc/object/Unit.h
@@ -10,7 +10,6 @@ public:
 	Unit(unsigned int id, unsigned int teamId, Position pos, unsigned int unit_type);
 
 	void tick(unsigned long long tickCount, Game *game);
-	std::unique_ptr<Object> &clone(Position newPos, Game *game) const;
 
 	unsigned int getUnitType() const { return unit_type_; }
 	unsigned int getTeamId() const { return team_id_; }

--- a/inc/object/Unit.h
+++ b/inc/object/Unit.h
@@ -8,7 +8,7 @@
 class Unit : public Object
 {
 public:
-	Unit(unsigned int id, unsigned int teamId, Position pos, unsigned int unit_type);
+	Unit(unsigned int id, unsigned int teamId, unsigned int unit_type);
 	Unit(const Unit &other)
 		: Object(other), unit_type_(other.unit_type_), team_id_(other.team_id_),
 		  balance_(other.balance_), next_move_opp_(other.next_move_opp_) {}

--- a/inc/object/Wall.h
+++ b/inc/object/Wall.h
@@ -8,6 +8,8 @@ class Wall : public Object
 {
 	public:
 		Wall(unsigned int id, Position pos);
+		Wall(const Wall &other)
+			: Object(other) {}
 
 		void tick(unsigned long long tickCount, Game * game);
 };

--- a/inc/object/Wall.h
+++ b/inc/object/Wall.h
@@ -3,6 +3,7 @@
 
 #include "Object.h"
 #include "Common.h"
+#include "Config.h"
 
 class Wall : public Object
 {
@@ -11,7 +12,7 @@ class Wall : public Object
 		Wall(const Wall &other)
 			: Object(other) {}
 
-		void tick(unsigned long long tickCount, Game * game);
+		void tick(unsigned long long tickCount);
 };
 
 #endif // WALL_H

--- a/inc/object/Wall.h
+++ b/inc/object/Wall.h
@@ -10,7 +10,6 @@ class Wall : public Object
 		Wall(unsigned int id, Position pos);
 
 		void tick(unsigned long long tickCount, Game * game);
-		std::unique_ptr<Object> & clone(Position newPos, Game * game) const;
 };
 
 #endif // WALL_H

--- a/inc/object/Wall.h
+++ b/inc/object/Wall.h
@@ -8,7 +8,7 @@
 class Wall : public Object
 {
 	public:
-		Wall(unsigned int id, Position pos);
+		Wall(unsigned int id);
 		Wall(const Wall &other)
 			: Object(other) {}
 

--- a/inc/utils/Utils.h
+++ b/inc/utils/Utils.h
@@ -9,7 +9,7 @@ class Game;
 #include <random>
 #include <algorithm>
 
-Position findFirstEmptyGridCell(Game* game, Position startPos);
+Position findFirstEmptyGridCell(Position startPos);
 
 template <typename T>
 void shuffle_vector(std::vector<T> & vec)

--- a/src/Config/Config.cpp
+++ b/src/Config/Config.cpp
@@ -5,11 +5,6 @@ std::string Config::configFilePath = "";
 #include "JigsawWorldGenerator.h"
 #include "DistancedResourceWorldGenerator.h"
 
-namespace
-{
-	std::unique_ptr<GameConfig> configInstance;
-}
-
 GameConfig parseConfig()
 {
 	GameConfig config;
@@ -97,25 +92,24 @@ GameConfig parseConfig()
 	return config;
 }
 
-GameConfig &Config::getInstance()
+GameConfig &Config::instance()
 {
-	if (!configInstance)
-		configInstance = std::make_unique<GameConfig>(parseConfig());
-	return *configInstance;
+	static GameConfig configInstance = parseConfig();
+	return configInstance;
 }
 
 Position &Config::getCorePosition(unsigned int teamId)
 {
-	return getInstance().corePositions[teamId];
+	return instance().corePositions[teamId];
 }
 UnitConfig &Config::getUnitConfig(unsigned int unit_type)
 {
-	return getInstance().units[unit_type];
+	return instance().units[unit_type];
 }
 
 json Config::encodeConfig()
 {
-	const GameConfig &config = Config::getInstance();
+	const GameConfig &config = Config::instance();
 
 	json configJson;
 

--- a/src/Config/worldgen/DistancedResourceWorldGenerator.cpp
+++ b/src/Config/worldgen/DistancedResourceWorldGenerator.cpp
@@ -46,7 +46,7 @@ void DistancedResourceWorldGenerator::generateWorld(Game *game)
 		std::uniform_int_distribution<int> resourceOrMoney(0, Config::getInstance().worldGeneratorConfig.value("moneyChance", 4) - 1);
 		if (resourceOrMoney(eng_) == 0)
 			game->board_.addObject<Money>(Money(game->board_.getNextObjectId(), randPos));
-			else
+		else
 			game->board_.addObject<Resource>(Resource(game->board_.getNextObjectId(), randPos));
 	}
 

--- a/src/Config/worldgen/DistancedResourceWorldGenerator.cpp
+++ b/src/Config/worldgen/DistancedResourceWorldGenerator.cpp
@@ -4,13 +4,13 @@ DistancedResourceWorldGenerator::DistancedResourceWorldGenerator()
 {
 }
 
-void DistancedResourceWorldGenerator::generateWorld(Game *game)
+void DistancedResourceWorldGenerator::generateWorld()
 {
 	Logger::Log("Generating world of type distanced resources.");
 
-	unsigned int width = Config::getInstance().width;
-	unsigned int height = Config::getInstance().height;
-	int resourceCount = Config::getInstance().worldGeneratorConfig.value("resourceOrMoneyCount", 20);
+	unsigned int width = Config::instance().width;
+	unsigned int height = Config::instance().height;
+	int resourceCount = Config::instance().worldGeneratorConfig.value("resourceOrMoneyCount", 20);
 
 	// place objects randomly
 
@@ -30,7 +30,7 @@ void DistancedResourceWorldGenerator::generateWorld(Game *game)
 		{
 			for (int y = -1; y >= 1; y++)
 			{
-				if (game->board_.getObjectAtPos(Position(x, y)))
+				if (Board::instance().getObjectAtPos(Position(x, y)))
 				{
 					noNeighbours = false;
 					break;
@@ -43,25 +43,25 @@ void DistancedResourceWorldGenerator::generateWorld(Game *game)
 			continue; // repick another position
 		}
 
-		std::uniform_int_distribution<int> resourceOrMoney(0, Config::getInstance().worldGeneratorConfig.value("moneyChance", 4) - 1);
+		std::uniform_int_distribution<int> resourceOrMoney(0, Config::instance().worldGeneratorConfig.value("moneyChance", 4) - 1);
 		if (resourceOrMoney(eng_) == 0)
-			game->board_.addObject<Money>(Money(game->board_.getNextObjectId(), randPos));
+			Board::instance().addObject<Money>(Money(Board::instance().getNextObjectId(), randPos));
 		else
-			game->board_.addObject<Resource>(Resource(game->board_.getNextObjectId(), randPos));
+			Board::instance().addObject<Resource>(Resource(Board::instance().getNextObjectId(), randPos));
 	}
 
 	// mirror playing field
 
-	for (auto &obj : game->board_)
+	for (auto &obj : Board::instance())
 	{
 		Position pos = obj.getPosition();
 		double ratio = static_cast<double>(pos.x) / (width - 1) +
 						static_cast<double>(pos.y) / (height - 1);
 		if (ratio >= 1.0 && obj.getType() != ObjectType::Core)
-			game->board_.removeObjectById(obj.getId());
+			Board::instance().removeObjectById(obj.getId());
 	}
 
-	for (auto &obj : game->board_)
+	for (auto &obj : Board::instance())
 	{
 		if (obj.getType() == ObjectType::Core)
 			continue;
@@ -70,10 +70,10 @@ void DistancedResourceWorldGenerator::generateWorld(Game *game)
 		switch (obj.getType())
 		{
 			case ObjectType::Resource:
-				game->board_.addObject<Resource>(Resource(obj.getId(), newPos));
+				Board::instance().addObject<Resource>(Resource(obj.getId(), newPos));
 				break;
 			case ObjectType::Money:
-				game->board_.addObject<Money>(Money(obj.getId(), newPos));
+				Board::instance().addObject<Money>(Money(obj.getId(), newPos));
 				break;
 			default:
 				Logger::Log("Unknown object type while mirroring: " + std::to_string(static_cast<int>(obj.getType())));

--- a/src/Config/worldgen/DistancedResourceWorldGenerator.cpp
+++ b/src/Config/worldgen/DistancedResourceWorldGenerator.cpp
@@ -45,16 +45,16 @@ void DistancedResourceWorldGenerator::generateWorld()
 
 		std::uniform_int_distribution<int> resourceOrMoney(0, Config::instance().worldGeneratorConfig.value("moneyChance", 4) - 1);
 		if (resourceOrMoney(eng_) == 0)
-			Board::instance().addObject<Money>(Money(Board::instance().getNextObjectId(), randPos));
+			Board::instance().addObject<Money>(Money(Board::instance().getNextObjectId()), randPos);
 		else
-			Board::instance().addObject<Resource>(Resource(Board::instance().getNextObjectId(), randPos));
+			Board::instance().addObject<Resource>(Resource(Board::instance().getNextObjectId()), randPos);
 	}
 
 	// mirror playing field
 
 	for (auto &obj : Board::instance())
 	{
-		Position pos = obj.getPosition();
+		Position pos = Board::instance().getObjectPositionById(obj.getId());
 		double ratio = static_cast<double>(pos.x) / (width - 1) +
 						static_cast<double>(pos.y) / (height - 1);
 		if (ratio >= 1.0 && obj.getType() != ObjectType::Core)
@@ -65,15 +65,15 @@ void DistancedResourceWorldGenerator::generateWorld()
 	{
 		if (obj.getType() == ObjectType::Core)
 			continue;
-		Position pos = obj.getPosition();
+		Position pos = Board::instance().getObjectPositionById(obj.getId());
 		Position newPos(height - 1 - pos.x, width - 1 - pos.y);
 		switch (obj.getType())
 		{
 			case ObjectType::Resource:
-				Board::instance().addObject<Resource>(Resource(obj.getId(), newPos));
+				Board::instance().addObject<Resource>(Resource(obj.getId()), newPos);
 				break;
 			case ObjectType::Money:
-				Board::instance().addObject<Money>(Money(obj.getId(), newPos));
+				Board::instance().addObject<Money>(Money(obj.getId()), newPos);
 				break;
 			default:
 				Logger::Log("Unknown object type while mirroring: " + std::to_string(static_cast<int>(obj.getType())));

--- a/src/Config/worldgen/DistancedResourceWorldGenerator.cpp
+++ b/src/Config/worldgen/DistancedResourceWorldGenerator.cpp
@@ -45,9 +45,9 @@ void DistancedResourceWorldGenerator::generateWorld(Game *game)
 
 		std::uniform_int_distribution<int> resourceOrMoney(0, Config::getInstance().worldGeneratorConfig.value("moneyChance", 4) - 1);
 		if (resourceOrMoney(eng_) == 0)
-			game->board_.addObject(Money(game->board_.getNextObjectId(), randPos));
+			game->board_.addObject<Money>(Money(game->board_.getNextObjectId(), randPos));
 			else
-			game->board_.addObject(Resource(game->board_.getNextObjectId(), randPos));
+			game->board_.addObject<Resource>(Resource(game->board_.getNextObjectId(), randPos));
 	}
 
 	// mirror playing field
@@ -66,9 +66,18 @@ void DistancedResourceWorldGenerator::generateWorld(Game *game)
 		if (obj.getType() == ObjectType::Core)
 			continue;
 		Position pos = obj.getPosition();
-		int newX = height - 1 - pos.x;
-		int newY = width - 1 - pos.y;
-		Position newPos(newX, newY);
-		obj.clone(newPos, game);
+		Position newPos(height - 1 - pos.x, width - 1 - pos.y);
+		switch (obj.getType())
+		{
+			case ObjectType::Resource:
+				game->board_.addObject<Resource>(Resource(obj.getId(), newPos));
+				break;
+			case ObjectType::Money:
+				game->board_.addObject<Money>(Money(obj.getId(), newPos));
+				break;
+			default:
+				Logger::Log("Unknown object type while mirroring: " + std::to_string(static_cast<int>(obj.getType())));
+				break;
+		}
 	}
 }

--- a/src/Config/worldgen/JigsawWorldGenerator/JigsawWorldGenerator.cpp
+++ b/src/Config/worldgen/JigsawWorldGenerator/JigsawWorldGenerator.cpp
@@ -101,40 +101,40 @@ bool JigsawWorldGenerator::tryPlaceTemplate(Game *game, const MapTemplate &temp,
 
 			Position targetPos(posX + x, posY + y);
 			if (cell == 'X')
-				game->board_.addObject(Wall(game->board_.getNextObjectId(), targetPos));
+				game->board_.addObject<Wall>(Wall(game->board_.getNextObjectId(), targetPos));
 			else if (cell == 'R')
-				game->board_.addObject(Resource(game->board_.getNextObjectId(), targetPos));
+				game->board_.addObject<Resource>(Resource(game->board_.getNextObjectId(), targetPos));
 			else if (cell == 'M')
-				game->board_.addObject(Money(game->board_.getNextObjectId(), targetPos));
+				game->board_.addObject<Money>(Money(game->board_.getNextObjectId(), targetPos));
 			else if (std::string("0123456789").find(cell) != std::string::npos)
 			{
 				int wallLikelihood = cell - '0';
 				std::uniform_int_distribution<int> dist(0, 9);
 				if (dist(eng_) < wallLikelihood)
-					game->board_.addObject(Wall(game->board_.getNextObjectId(), targetPos));
+					game->board_.addObject<Wall>(Wall(game->board_.getNextObjectId(), targetPos));
 			}
 			else if (std::string("abcdefghij").find(cell) != std::string::npos)
 			{
 				int resourceLikelihood = cell - 'a';
 				std::uniform_int_distribution<int> dist(0, 9);
 				if (dist(eng_) < resourceLikelihood)
-					game->board_.addObject(Resource(game->board_.getNextObjectId(), targetPos));
+					game->board_.addObject<Resource>(Resource(game->board_.getNextObjectId(), targetPos));
 			}
 			else if (std::string("ABCDEFGHIJ").find(cell) != std::string::npos)
 			{
 				int moneyLikelihood = cell - 'A';
 				std::uniform_int_distribution<int> dist(0, 9);
 				if (dist(eng_) < moneyLikelihood)
-					game->board_.addObject(Money(game->board_.getNextObjectId(), targetPos));
+					game->board_.addObject<Money>(Money(game->board_.getNextObjectId(), targetPos));
 			}
 			else if (std::string("klmnopqrst").find(cell) != std::string::npos)
 			{
 				int wallLikelihood = cell - 'k';
 				std::uniform_int_distribution<int> dist(0, 9);
 				if (dist(eng_) < wallLikelihood)
-					game->board_.addObject(Wall(game->board_.getNextObjectId(), targetPos));
+					game->board_.addObject<Wall>(Wall(game->board_.getNextObjectId(), targetPos));
 				else
-					game->board_.addObject(Resource(game->board_.getNextObjectId(), targetPos));
+					game->board_.addObject<Resource>(Resource(game->board_.getNextObjectId(), targetPos));
 			}
 			else if (std::string("uvwxyz!/$%").find(cell) != std::string::npos)
 			{
@@ -149,9 +149,9 @@ bool JigsawWorldGenerator::tryPlaceTemplate(Game *game, const MapTemplate &temp,
 					moneyLikelihood = 9;
 				std::uniform_int_distribution<int> dist(0, 9);
 				if (dist(eng_) < moneyLikelihood)
-					game->board_.addObject(Money(game->board_.getNextObjectId(), targetPos));
+					game->board_.addObject<Money>(Money(game->board_.getNextObjectId(), targetPos));
 				else
-					game->board_.addObject(Wall(game->board_.getNextObjectId(), targetPos));
+					game->board_.addObject<Wall>(Wall(game->board_.getNextObjectId(), targetPos));
 			}
 			else if (std::string("KLNOPQSTUV").find(cell) != std::string::npos)
 			{
@@ -161,9 +161,9 @@ bool JigsawWorldGenerator::tryPlaceTemplate(Game *game, const MapTemplate &temp,
 					int moneyLikelihood = it->second;
 					std::uniform_int_distribution<int> dist(0, 9);
 					if (dist(eng_) < moneyLikelihood)
-						game->board_.addObject(Money(game->board_.getNextObjectId(), targetPos));
+						game->board_.addObject<Money>(Money(game->board_.getNextObjectId(), targetPos));
 					else
-						game->board_.addObject(Resource(game->board_.getNextObjectId(), targetPos));
+						game->board_.addObject<Resource>(Resource(game->board_.getNextObjectId(), targetPos));
 				}
 			}
 		}
@@ -246,9 +246,9 @@ void JigsawWorldGenerator::balanceObjectType(Game *game, ObjectType type, int am
 			if (game->board_.getObjectAtPos(pos) == nullptr)
 			{
 				if (type == ObjectType::Resource)
-					game->board_.addObject(Resource(game->board_.getNextObjectId(), pos));
+					game->board_.addObject<Resource>(Resource(game->board_.getNextObjectId(), pos));
 				else
-					game->board_.addObject(Money(game->board_.getNextObjectId(), pos));
+					game->board_.addObject<Money>(Money(game->board_.getNextObjectId(), pos));
 				addCount--;
 			}
 		}
@@ -422,7 +422,7 @@ void JigsawWorldGenerator::placeWalls(Game *game)
 			placementProbability = 0.2;
 
 		if (probDist(eng_) < placementProbability)
-			game->board_.addObject(Wall(game->board_.getNextObjectId(), pos));
+			game->board_.addObject<Wall>(Wall(game->board_.getNextObjectId(), pos));
 	}
 }
 

--- a/src/Config/worldgen/JigsawWorldGenerator/JigsawWorldGenerator.cpp
+++ b/src/Config/worldgen/JigsawWorldGenerator/JigsawWorldGenerator.cpp
@@ -65,7 +65,7 @@ bool JigsawWorldGenerator::canPlaceTemplate(const MapTemplate &temp, int posX, i
 			}
 
 			for (const auto &obj : Board::instance())
-				if (obj.getType() == ObjectType::Core && ((Core &)obj).getPosition().distance(targetPos) < minCoreDistance)
+				if (obj.getType() == ObjectType::Core && Board::instance().getObjectPositionById(obj.getId()).distance(targetPos) < minCoreDistance)
 					return false;
 		}
 	}
@@ -101,40 +101,40 @@ bool JigsawWorldGenerator::tryPlaceTemplate(const MapTemplate &temp, int posX, i
 
 			Position targetPos(posX + x, posY + y);
 			if (cell == 'X')
-				Board::instance().addObject<Wall>(Wall(Board::instance().getNextObjectId(), targetPos));
+				Board::instance().addObject<Wall>(Wall(Board::instance().getNextObjectId()), targetPos);
 			else if (cell == 'R')
-				Board::instance().addObject<Resource>(Resource(Board::instance().getNextObjectId(), targetPos));
+				Board::instance().addObject<Resource>(Resource(Board::instance().getNextObjectId()), targetPos);
 			else if (cell == 'M')
-				Board::instance().addObject<Money>(Money(Board::instance().getNextObjectId(), targetPos));
+				Board::instance().addObject<Money>(Money(Board::instance().getNextObjectId()), targetPos);
 			else if (std::string("0123456789").find(cell) != std::string::npos)
 			{
 				int wallLikelihood = cell - '0';
 				std::uniform_int_distribution<int> dist(0, 9);
 				if (dist(eng_) < wallLikelihood)
-					Board::instance().addObject<Wall>(Wall(Board::instance().getNextObjectId(), targetPos));
+					Board::instance().addObject<Wall>(Wall(Board::instance().getNextObjectId()), targetPos);
 			}
 			else if (std::string("abcdefghij").find(cell) != std::string::npos)
 			{
 				int resourceLikelihood = cell - 'a';
 				std::uniform_int_distribution<int> dist(0, 9);
 				if (dist(eng_) < resourceLikelihood)
-					Board::instance().addObject<Resource>(Resource(Board::instance().getNextObjectId(), targetPos));
+					Board::instance().addObject<Resource>(Resource(Board::instance().getNextObjectId()), targetPos);
 			}
 			else if (std::string("ABCDEFGHIJ").find(cell) != std::string::npos)
 			{
 				int moneyLikelihood = cell - 'A';
 				std::uniform_int_distribution<int> dist(0, 9);
 				if (dist(eng_) < moneyLikelihood)
-					Board::instance().addObject<Money>(Money(Board::instance().getNextObjectId(), targetPos));
+					Board::instance().addObject<Money>(Money(Board::instance().getNextObjectId()), targetPos);
 			}
 			else if (std::string("klmnopqrst").find(cell) != std::string::npos)
 			{
 				int wallLikelihood = cell - 'k';
 				std::uniform_int_distribution<int> dist(0, 9);
 				if (dist(eng_) < wallLikelihood)
-					Board::instance().addObject<Wall>(Wall(Board::instance().getNextObjectId(), targetPos));
+					Board::instance().addObject<Wall>(Wall(Board::instance().getNextObjectId()), targetPos);
 				else
-					Board::instance().addObject<Resource>(Resource(Board::instance().getNextObjectId(), targetPos));
+					Board::instance().addObject<Resource>(Resource(Board::instance().getNextObjectId()), targetPos);
 			}
 			else if (std::string("uvwxyz!/$%").find(cell) != std::string::npos)
 			{
@@ -149,9 +149,9 @@ bool JigsawWorldGenerator::tryPlaceTemplate(const MapTemplate &temp, int posX, i
 					moneyLikelihood = 9;
 				std::uniform_int_distribution<int> dist(0, 9);
 				if (dist(eng_) < moneyLikelihood)
-					Board::instance().addObject<Money>(Money(Board::instance().getNextObjectId(), targetPos));
+					Board::instance().addObject<Money>(Money(Board::instance().getNextObjectId()), targetPos);
 				else
-					Board::instance().addObject<Wall>(Wall(Board::instance().getNextObjectId(), targetPos));
+					Board::instance().addObject<Wall>(Wall(Board::instance().getNextObjectId()), targetPos);
 			}
 			else if (std::string("KLNOPQSTUV").find(cell) != std::string::npos)
 			{
@@ -161,9 +161,9 @@ bool JigsawWorldGenerator::tryPlaceTemplate(const MapTemplate &temp, int posX, i
 					int moneyLikelihood = it->second;
 					std::uniform_int_distribution<int> dist(0, 9);
 					if (dist(eng_) < moneyLikelihood)
-						Board::instance().addObject<Money>(Money(Board::instance().getNextObjectId(), targetPos));
+						Board::instance().addObject<Money>(Money(Board::instance().getNextObjectId()), targetPos);
 					else
-						Board::instance().addObject<Resource>(Resource(Board::instance().getNextObjectId(), targetPos));
+						Board::instance().addObject<Resource>(Resource(Board::instance().getNextObjectId()), targetPos);
 				}
 			}
 		}
@@ -209,7 +209,7 @@ void JigsawWorldGenerator::balanceObjectType(ObjectType type, int amount)
 			bool nearCore = false;
 			for (const Object & obj : Board::instance())
 			{
-				if (obj.getType() == ObjectType::Core && ((Core &)obj).getPosition().distance(pos) < minCoreDistance)
+				if (obj.getType() == ObjectType::Core && Board::instance().getObjectPositionById(obj.getId()).distance(pos) < minCoreDistance)
 				{
 					nearCore = true;
 					break;
@@ -246,9 +246,9 @@ void JigsawWorldGenerator::balanceObjectType(ObjectType type, int amount)
 			if (Board::instance().getObjectAtPos(pos) == nullptr)
 			{
 				if (type == ObjectType::Resource)
-					Board::instance().addObject<Resource>(Resource(Board::instance().getNextObjectId(), pos));
+					Board::instance().addObject<Resource>(Resource(Board::instance().getNextObjectId()), pos);
 				else
-					Board::instance().addObject<Money>(Money(Board::instance().getNextObjectId(), pos));
+					Board::instance().addObject<Money>(Money(Board::instance().getNextObjectId()), pos);
 				addCount--;
 			}
 		}
@@ -266,9 +266,9 @@ void JigsawWorldGenerator::clearPathBetweenCores()
 		if (obj.getType() != ObjectType::Core)
 			continue;
 		if (coreNbr == 0)
-			start = obj.getPosition();
+			start = Board::instance().getObjectPositionById(obj.getId());
 		else
-			end = obj.getPosition();
+			end = Board::instance().getObjectPositionById(obj.getId());
 	}
 
 	int W = Config::instance().width;
@@ -352,7 +352,7 @@ void JigsawWorldGenerator::clearPathBetweenCores()
 	for (const auto &pos : path)
 	{
 		for (const Object & obj : Board::instance())
-			if (obj.getPosition() == pos && obj.getType() != ObjectType::Core)
+			if (Board::instance().getObjectPositionById(obj.getId()) == pos && obj.getType() != ObjectType::Core)
 				Board::instance().removeObjectById(obj.getId());
 
 		if (!Config::instance().worldGeneratorConfig.value("mirrorMap", true))
@@ -360,7 +360,7 @@ void JigsawWorldGenerator::clearPathBetweenCores()
 
 		Position mirrorPos((W - 1) - pos.x, (H - 1) - pos.y);
 		for (const Object & obj : Board::instance())
-			if (obj.getPosition() == mirrorPos && obj.getType() != ObjectType::Core)
+			if (Board::instance().getObjectPositionById(obj.getId()) == mirrorPos && obj.getType() != ObjectType::Core)
 				Board::instance().removeObjectById(obj.getId());
 	}
 }
@@ -386,7 +386,7 @@ void JigsawWorldGenerator::placeWalls()
 		bool nearCore = false;
 		for (const Object & obj : Board::instance())
 		{
-			if (obj.getType() == ObjectType::Core && ((Core &)obj).getPosition().distance(pos) < minCoreDistance)
+			if (obj.getType() == ObjectType::Core && Board::instance().getObjectPositionById(obj.getId()).distance(pos) < minCoreDistance)
 			{
 				nearCore = true;
 				break;
@@ -422,7 +422,7 @@ void JigsawWorldGenerator::placeWalls()
 			placementProbability = 0.2;
 
 		if (probDist(eng_) < placementProbability)
-			Board::instance().addObject<Wall>(Wall(Board::instance().getNextObjectId(), pos));
+			Board::instance().addObject<Wall>(Wall(Board::instance().getNextObjectId()), pos);
 	}
 }
 
@@ -435,7 +435,7 @@ void JigsawWorldGenerator::mirrorWorld()
 	{
 		if (obj.getType() == ObjectType::Core)
 			continue;
-		Position p = obj.getPosition();
+		Position p = Board::instance().getObjectPositionById(obj.getId());
 		Position q(W - 1 - p.x, H - 1 - p.y);
 		bool isBase =
 			(p.y < q.y) ||
@@ -447,7 +447,7 @@ void JigsawWorldGenerator::mirrorWorld()
 	{
 		if (obj.getType() == ObjectType::Core)
 			continue;
-		Position p = obj.getPosition();
+		Position p = Board::instance().getObjectPositionById(obj.getId());
 		Position q(W - 1 - p.x, H - 1 - p.y);
 		bool isBase =
 			(p.y < q.y) ||

--- a/src/Config/worldgen/WorldGenerator.cpp
+++ b/src/Config/worldgen/WorldGenerator.cpp
@@ -1,5 +1,0 @@
-#include "WorldGenerator.h"
-
-WorldGenerator::WorldGenerator()
-{
-}

--- a/src/action/AttackAction.cpp
+++ b/src/action/AttackAction.cpp
@@ -65,7 +65,7 @@ bool AttackAction::attackObj(Object *obj, Unit *unit, Game *game) // returns obj
 	else if (obj->getType() == ObjectType::Money)
 	{
 		unit->setBalance(unit->getBalance() + ((Money *)obj)->getBalance());
-		game->removeObjectById(obj->getId());
+		game->board_.removeObjectById(obj->getId());
 		damage_ = 1;
 	}
 
@@ -77,7 +77,7 @@ bool AttackAction::execute(Game *game, Core *core)
 	if (!is_valid_)
 		return false;
 
-	Object *unitObj = game->getObject(getUnitId());
+	Object *unitObj = game->board_.getObjectById(getUnitId());
 
 	if (!unitObj || unitObj->getType() != ObjectType::Unit)
 		return false;
@@ -89,7 +89,7 @@ bool AttackAction::execute(Game *game, Core *core)
 
 	if (Config::getInstance().units[unit->getUnitType()].attackType == AttackType::DIRECT_HIT)
 	{
-		Object *obj = game->getObjectAtPos(target_pos_);
+		Object *obj = game->board_.getObjectAtPos(target_pos_);
 		if (!obj)
 			return false;
 
@@ -98,12 +98,11 @@ bool AttackAction::execute(Game *game, Core *core)
 	}
 	else if (Config::getInstance().units[unit->getUnitType()].attackType == AttackType::DROP_BOMB)
 	{
-		Object *obj = game->getObjectAtPos(target_pos_);
+		Object *obj = game->board_.getObjectAtPos(target_pos_);
 		if (obj)
 			return false;
 
-		game->getObjects().push_back(
-			std::make_unique<Bomb>(game->getNextObjectId(), target_pos_));
+		game->board_.addObject<Bomb>(Bomb(game->board_.getNextObjectId(), target_pos_));
 	}
 	else
 	{

--- a/src/action/AttackAction.cpp
+++ b/src/action/AttackAction.cpp
@@ -19,7 +19,7 @@ void AttackAction::decodeJSON(json msg)
 	target_pos_.x = msg["target_pos_x"];
 	target_pos_.y = msg["target_pos_y"];
 
-	if (!target_pos_.isValid(Config::getInstance().width, Config::getInstance().height))
+	if (!target_pos_.isValid(Config::instance().width, Config::instance().height))
 	{
 		is_valid_ = false;
 		return;
@@ -38,46 +38,46 @@ json AttackAction::encodeJSON()
 	return js;
 }
 
-bool AttackAction::attackObj(Object *obj, Unit *unit, Game *game) // returns object new hp, 1 if no object present
+bool AttackAction::attackObj(Object *obj, Unit *unit) // returns object new hp, 1 if no object present
 {
 	if (!obj)
 		return false;
 	if (obj->getType() == ObjectType::Unit)
 	{
-		obj->setHP(obj->getHP() - Config::getInstance().units[unit->getUnitType()].damageUnit);
-		damage_ = Config::getInstance().units[unit->getUnitType()].damageUnit;
+		obj->setHP(obj->getHP() - Config::instance().units[unit->getUnitType()].damageUnit);
+		damage_ = Config::instance().units[unit->getUnitType()].damageUnit;
 	}
 	else if (obj->getType() == ObjectType::Core)
 	{
-		obj->setHP(obj->getHP() - Config::getInstance().units[unit->getUnitType()].damageCore);
-		damage_ = Config::getInstance().units[unit->getUnitType()].damageCore;
+		obj->setHP(obj->getHP() - Config::instance().units[unit->getUnitType()].damageCore);
+		damage_ = Config::instance().units[unit->getUnitType()].damageCore;
 	}
 	else if (obj->getType() == ObjectType::Resource)
 	{
 		((Resource *)obj)->getMined(unit);
-		damage_ = Config::getInstance().units[unit->getUnitType()].damageResource;
+		damage_ = Config::instance().units[unit->getUnitType()].damageResource;
 	}
 	else if (obj->getType() == ObjectType::Wall)
 	{
-		obj->setHP(obj->getHP() - Config::getInstance().units[unit->getUnitType()].damageWall);
-		damage_ = Config::getInstance().units[unit->getUnitType()].damageWall;
+		obj->setHP(obj->getHP() - Config::instance().units[unit->getUnitType()].damageWall);
+		damage_ = Config::instance().units[unit->getUnitType()].damageWall;
 	}
 	else if (obj->getType() == ObjectType::Money)
 	{
 		unit->setBalance(unit->getBalance() + ((Money *)obj)->getBalance());
-		game->board_.removeObjectById(obj->getId());
+		Board::instance().removeObjectById(obj->getId());
 		damage_ = 1;
 	}
 
 	return true;
 }
 
-bool AttackAction::execute(Game *game, Core *core)
+bool AttackAction::execute(Core *core)
 {
 	if (!is_valid_)
 		return false;
 
-	Object *unitObj = game->board_.getObjectById(getUnitId());
+	Object *unitObj = Board::instance().getObjectById(getUnitId());
 
 	if (!unitObj || unitObj->getType() != ObjectType::Unit)
 		return false;
@@ -87,22 +87,22 @@ bool AttackAction::execute(Game *game, Core *core)
 	if (unit->getTeamId() != core->getTeamId())
 		return false;
 
-	if (Config::getInstance().units[unit->getUnitType()].attackType == AttackType::DIRECT_HIT)
+	if (Config::instance().units[unit->getUnitType()].attackType == AttackType::DIRECT_HIT)
 	{
-		Object *obj = game->board_.getObjectAtPos(target_pos_);
+		Object *obj = Board::instance().getObjectAtPos(target_pos_);
 		if (!obj)
 			return false;
 
-		if (!attackObj(obj, unit, game))
+		if (!attackObj(obj, unit))
 			return false;
 	}
-	else if (Config::getInstance().units[unit->getUnitType()].attackType == AttackType::DROP_BOMB)
+	else if (Config::instance().units[unit->getUnitType()].attackType == AttackType::DROP_BOMB)
 	{
-		Object *obj = game->board_.getObjectAtPos(target_pos_);
+		Object *obj = Board::instance().getObjectAtPos(target_pos_);
 		if (obj)
 			return false;
 
-		game->board_.addObject<Bomb>(Bomb(game->board_.getNextObjectId(), target_pos_));
+		Board::instance().addObject<Bomb>(Bomb(Board::instance().getNextObjectId(), target_pos_));
 	}
 	else
 	{

--- a/src/action/AttackAction.cpp
+++ b/src/action/AttackAction.cpp
@@ -102,7 +102,7 @@ bool AttackAction::execute(Core *core)
 		if (obj)
 			return false;
 
-		Board::instance().addObject<Bomb>(Bomb(Board::instance().getNextObjectId(), target_pos_));
+		Board::instance().addObject<Bomb>(Bomb(Board::instance().getNextObjectId()), target_pos_);
 	}
 	else
 	{

--- a/src/action/BuildAction.cpp
+++ b/src/action/BuildAction.cpp
@@ -47,14 +47,14 @@ bool BuildAction::execute(Core *core)
 	if (Board::instance().getObjectAtPos(position_) != nullptr)
 		return false;
 
-	if (position_.distance(builder->getPosition()) > 1)
+	if (position_.distance(Board::instance().getObjectPositionById(builder->getId())) > 1)
 		return false;
 
 	if (builder->getBalance() < Config::instance().wallBuildCost)
 		return false;
 	builder->setBalance(builder->getBalance() - Config::instance().wallBuildCost);
 
-	Board::instance().addObject<Wall>(Wall(Board::instance().getNextObjectId(), position_));
+	Board::instance().addObject<Wall>(Wall(Board::instance().getNextObjectId()), position_);
 
 	return true;
 }

--- a/src/action/BuildAction.cpp
+++ b/src/action/BuildAction.cpp
@@ -37,14 +37,14 @@ bool BuildAction::execute(Game *game, Core *core)
 	if (!is_valid_)
 		return false;
 
-	Object *builderObj = game->getObject(builder_id_);
+	Object *builderObj = game->board_.getObjectById(builder_id_);
 	if (builderObj == nullptr || builderObj->getType() != ObjectType::Unit)
 		return false;
 	Unit *builder = dynamic_cast<Unit *>(builderObj);
 	if (!Config::getInstance().units[builder->getUnitType()].canBuild)
 		return false;
 
-	if (game->getObjectAtPos(position_) != nullptr)
+	if (game->board_.getObjectAtPos(position_) != nullptr)
 		return false;
 
 	if (position_.distance(builder->getPosition()) > 1)
@@ -54,7 +54,7 @@ bool BuildAction::execute(Game *game, Core *core)
 		return false;
 	builder->setBalance(builder->getBalance() - Config::getInstance().wallBuildCost);
 
-	game->getObjects().push_back(std::make_unique<Wall>(game->getNextObjectId(), position_));
+	game->board_.addObject<Wall>(Wall(game->board_.getNextObjectId(), position_));
 
 	return true;
 }

--- a/src/action/BuildAction.cpp
+++ b/src/action/BuildAction.cpp
@@ -16,7 +16,7 @@ void BuildAction::decodeJSON(json msg)
 	builder_id_ = msg["builder_id"];
 	position_ = Position(msg["x"], msg["y"]);
 
-	if (!position_.isValid(Config::getInstance().width, Config::getInstance().height))
+	if (!position_.isValid(Config::instance().width, Config::instance().height))
 		is_valid_ = false;
 }
 json BuildAction::encodeJSON()
@@ -31,30 +31,30 @@ json BuildAction::encodeJSON()
 	return js;
 }
 
-bool BuildAction::execute(Game *game, Core *core)
+bool BuildAction::execute(Core *core)
 {
 	(void)core;
 	if (!is_valid_)
 		return false;
 
-	Object *builderObj = game->board_.getObjectById(builder_id_);
+	Object *builderObj = Board::instance().getObjectById(builder_id_);
 	if (builderObj == nullptr || builderObj->getType() != ObjectType::Unit)
 		return false;
 	Unit *builder = dynamic_cast<Unit *>(builderObj);
-	if (!Config::getInstance().units[builder->getUnitType()].canBuild)
+	if (!Config::instance().units[builder->getUnitType()].canBuild)
 		return false;
 
-	if (game->board_.getObjectAtPos(position_) != nullptr)
+	if (Board::instance().getObjectAtPos(position_) != nullptr)
 		return false;
 
 	if (position_.distance(builder->getPosition()) > 1)
 		return false;
 
-	if (builder->getBalance() < Config::getInstance().wallBuildCost)
+	if (builder->getBalance() < Config::instance().wallBuildCost)
 		return false;
-	builder->setBalance(builder->getBalance() - Config::getInstance().wallBuildCost);
+	builder->setBalance(builder->getBalance() - Config::instance().wallBuildCost);
 
-	game->board_.addObject<Wall>(Wall(game->board_.getNextObjectId(), position_));
+	Board::instance().addObject<Wall>(Wall(Board::instance().getNextObjectId(), position_));
 
 	return true;
 }

--- a/src/action/CreateAction.cpp
+++ b/src/action/CreateAction.cpp
@@ -25,23 +25,23 @@ json CreateAction::encodeJSON()
 	return js;
 }
 
-bool CreateAction::execute(Game *game, Core *core)
+bool CreateAction::execute(Core *core)
 {
 	if (!is_valid_)
 		return false;
 
-	Position closestEmptyPos = findFirstEmptyGridCell(game, core->getPosition());
-	if (!closestEmptyPos.isValid(Config::getInstance().width, Config::getInstance().height))
+	Position closestEmptyPos = findFirstEmptyGridCell(core->getPosition());
+	if (!closestEmptyPos.isValid(Config::instance().width, Config::instance().height))
 		return false;
 
-	if (unit_type_ >= Config::getInstance().units.size())
+	if (unit_type_ >= Config::instance().units.size())
 		return false;
 
 	unsigned int unitCost = Config::getUnitConfig(unit_type_).cost;
 	if (core->getBalance() < unitCost)
 		return false;
 
-	game->board_.addObject<Unit>(Unit(game->board_.getNextObjectId(), core->getTeamId(), closestEmptyPos, unit_type_));
+	Board::instance().addObject<Unit>(Unit(Board::instance().getNextObjectId(), core->getTeamId(), closestEmptyPos, unit_type_));
 	core->setBalance(core->getBalance() - unitCost);
 
 	return true;

--- a/src/action/CreateAction.cpp
+++ b/src/action/CreateAction.cpp
@@ -30,7 +30,7 @@ bool CreateAction::execute(Core *core)
 	if (!is_valid_)
 		return false;
 
-	Position closestEmptyPos = findFirstEmptyGridCell(core->getPosition());
+	Position closestEmptyPos = findFirstEmptyGridCell(Board::instance().getObjectPositionById(core->getId()));
 	if (!closestEmptyPos.isValid(Config::instance().width, Config::instance().height))
 		return false;
 
@@ -41,7 +41,7 @@ bool CreateAction::execute(Core *core)
 	if (core->getBalance() < unitCost)
 		return false;
 
-	Board::instance().addObject<Unit>(Unit(Board::instance().getNextObjectId(), core->getTeamId(), closestEmptyPos, unit_type_));
+	Board::instance().addObject<Unit>(Unit(Board::instance().getNextObjectId(), core->getTeamId(), unit_type_), closestEmptyPos);
 	core->setBalance(core->getBalance() - unitCost);
 
 	return true;

--- a/src/action/CreateAction.cpp
+++ b/src/action/CreateAction.cpp
@@ -41,7 +41,7 @@ bool CreateAction::execute(Game *game, Core *core)
 	if (core->getBalance() < unitCost)
 		return false;
 
-	game->getObjects().push_back(std::make_unique<Unit>(game->getNextObjectId(), core->getTeamId(), closestEmptyPos, unit_type_));
+	game->board_.addObject<Unit>(Unit(game->board_.getNextObjectId(), core->getTeamId(), closestEmptyPos, unit_type_));
 	core->setBalance(core->getBalance() - unitCost);
 
 	return true;

--- a/src/action/MoveAction.cpp
+++ b/src/action/MoveAction.cpp
@@ -17,7 +17,7 @@ void MoveAction::decodeJSON(json msg)
 
 	unit_id_ = msg["unit_id"];
 	target_ = Position(msg["targetX"], msg["targetY"]);
-	if (!target_.isValid(Config::getInstance().width, Config::getInstance().height))
+	if (!target_.isValid(Config::instance().width, Config::instance().height))
 	{
 		is_valid_ = false;
 		return;
@@ -35,12 +35,12 @@ json MoveAction::encodeJSON()
 	return js;
 }
 
-bool MoveAction::execute(Game *game, Core * core)
+bool MoveAction::execute(Core * core)
 {
 	if (!is_valid_)
 		return false;
 
-	Object * unitObj = game->board_.getObjectById(getUnitId());
+	Object * unitObj = Board::instance().getObjectById(getUnitId());
 	if (!unitObj || unitObj->getType() != ObjectType::Unit)
 		return false;
 	Unit * unit = (Unit *)unitObj;
@@ -50,13 +50,13 @@ bool MoveAction::execute(Game *game, Core * core)
 	if (unit->getTeamId() != core->getTeamId())
 		return false;
 
-	Object * obj = game->board_.getObjectAtPos(target_);
+	Object * obj = Board::instance().getObjectAtPos(target_);
 	if (obj)
 		return false;
 	if (target_.distance(unit->getPosition()) > 1)
 		return false;
 
-	game->board_.moveObjectById(unit->getId(), target_);
+	Board::instance().moveObjectById(unit->getId(), target_);
 	unit->setPosition(target_);
 	unit->resetNextMoveOpp();
 

--- a/src/action/MoveAction.cpp
+++ b/src/action/MoveAction.cpp
@@ -53,7 +53,7 @@ bool MoveAction::execute(Core * core)
 	Object * obj = Board::instance().getObjectAtPos(target_);
 	if (obj)
 		return false;
-	if (target_.distance(Board::instance().getObjectPositionById(obj->getId())) > 1)
+	if (target_.distance(Board::instance().getObjectPositionById(unit->getId())) > 1)
 		return false;
 
 	Board::instance().moveObjectById(unit->getId(), target_);

--- a/src/action/MoveAction.cpp
+++ b/src/action/MoveAction.cpp
@@ -56,6 +56,7 @@ bool MoveAction::execute(Game *game, Core * core)
 	if (target_.distance(unit->getPosition()) > 1)
 		return false;
 
+	game->board_.moveObjectById(unit->getId(), target_);
 	unit->setPosition(target_);
 	unit->resetNextMoveOpp();
 

--- a/src/action/MoveAction.cpp
+++ b/src/action/MoveAction.cpp
@@ -53,11 +53,10 @@ bool MoveAction::execute(Core * core)
 	Object * obj = Board::instance().getObjectAtPos(target_);
 	if (obj)
 		return false;
-	if (target_.distance(unit->getPosition()) > 1)
+	if (target_.distance(Board::instance().getObjectPositionById(obj->getId())) > 1)
 		return false;
 
 	Board::instance().moveObjectById(unit->getId(), target_);
-	unit->setPosition(target_);
 	unit->resetNextMoveOpp();
 
 	return true;

--- a/src/action/MoveAction.cpp
+++ b/src/action/MoveAction.cpp
@@ -40,7 +40,7 @@ bool MoveAction::execute(Game *game, Core * core)
 	if (!is_valid_)
 		return false;
 
-	Object * unitObj = game->getObject(getUnitId());
+	Object * unitObj = game->board_.getObjectById(getUnitId());
 	if (!unitObj || unitObj->getType() != ObjectType::Unit)
 		return false;
 	Unit * unit = (Unit *)unitObj;
@@ -50,7 +50,7 @@ bool MoveAction::execute(Game *game, Core * core)
 	if (unit->getTeamId() != core->getTeamId())
 		return false;
 
-	Object * obj = game->getObjectAtPos(target_);
+	Object * obj = game->board_.getObjectAtPos(target_);
 	if (obj)
 		return false;
 	if (target_.distance(unit->getPosition()) > 1)

--- a/src/action/TransferMoneyAction.cpp
+++ b/src/action/TransferMoneyAction.cpp
@@ -52,7 +52,7 @@ bool TransferMoneyAction::dropMoney(Game *game, Core *core, Object *srcObj)
 	srcUnit->setBalance(srcUnit->getBalance() - amount_);
 
 	Position pos = srcUnit->getPosition();
-	game->getObjects().push_back(std::make_unique<Money>(game->getNextObjectId(), pos, amount_));
+	game->board_.addObject<Money>(Money(game->board_.getNextObjectId(), pos, amount_));
 
 	return true;
 }
@@ -62,11 +62,11 @@ bool TransferMoneyAction::execute(Game *game, Core *core)
 	if (!is_valid_)
 		return false;
 
-	Object *srcObj = game->getObject(source_id_);
+	Object *srcObj = game->board_.getObjectById(source_id_);
 	if (!srcObj)
 		return false;
 
-	Object *dstObj = game->getObjectAtPos(target_);
+	Object *dstObj = game->board_.getObjectAtPos(target_);
 	if (!dstObj)
 		return dropMoney(game, core, srcObj);
 

--- a/src/action/TransferMoneyAction.cpp
+++ b/src/action/TransferMoneyAction.cpp
@@ -37,10 +37,10 @@ bool TransferMoneyAction::dropMoney(Core *core, Object *srcObj)
 	if (srcObj->getType() != ObjectType::Unit)
 		return false;
 
-	if (srcObj->getPosition().distance(target_) > 1)
+	if (Board::instance().getObjectPositionById(srcObj->getId()).distance(target_) > 1)
 		return false;
 
-	if (srcObj->getPosition() == target_)
+	if (Board::instance().getObjectPositionById(srcObj->getId()) == target_)
 		return false;
 
 	Unit *srcUnit = (Unit *)srcObj;
@@ -51,8 +51,8 @@ bool TransferMoneyAction::dropMoney(Core *core, Object *srcObj)
 		amount_ = srcUnit->getBalance();
 	srcUnit->setBalance(srcUnit->getBalance() - amount_);
 
-	Position pos = srcUnit->getPosition();
-	Board::instance().addObject<Money>(Money(Board::instance().getNextObjectId(), pos, amount_));
+	Position pos = Board::instance().getObjectPositionById(srcObj->getId());
+	Board::instance().addObject<Money>(Money(Board::instance().getNextObjectId(), amount_), pos);
 
 	return true;
 }
@@ -77,7 +77,9 @@ bool TransferMoneyAction::execute(Core *core)
 		return false;
 
 	// only adjacent objects can transfer money
-	if (srcObj->getPosition().distance(dstObj->getPosition()) > 1)
+	Position srcPos = Board::instance().getObjectPositionById(srcObj->getId());
+	Position dstPos = Board::instance().getObjectPositionById(dstObj->getId());
+	if (srcPos.distance(dstPos) > 1)
 		return false;
 
 	unsigned int amount = amount_;

--- a/src/action/TransferMoneyAction.cpp
+++ b/src/action/TransferMoneyAction.cpp
@@ -32,7 +32,7 @@ json TransferMoneyAction::encodeJSON()
 	return js;
 }
 
-bool TransferMoneyAction::dropMoney(Game *game, Core *core, Object *srcObj)
+bool TransferMoneyAction::dropMoney(Core *core, Object *srcObj)
 {
 	if (srcObj->getType() != ObjectType::Unit)
 		return false;
@@ -52,23 +52,23 @@ bool TransferMoneyAction::dropMoney(Game *game, Core *core, Object *srcObj)
 	srcUnit->setBalance(srcUnit->getBalance() - amount_);
 
 	Position pos = srcUnit->getPosition();
-	game->board_.addObject<Money>(Money(game->board_.getNextObjectId(), pos, amount_));
+	Board::instance().addObject<Money>(Money(Board::instance().getNextObjectId(), pos, amount_));
 
 	return true;
 }
 
-bool TransferMoneyAction::execute(Game *game, Core *core)
+bool TransferMoneyAction::execute(Core *core)
 {
 	if (!is_valid_)
 		return false;
 
-	Object *srcObj = game->board_.getObjectById(source_id_);
+	Object *srcObj = Board::instance().getObjectById(source_id_);
 	if (!srcObj)
 		return false;
 
-	Object *dstObj = game->board_.getObjectAtPos(target_);
+	Object *dstObj = Board::instance().getObjectAtPos(target_);
 	if (!dstObj)
-		return dropMoney(game, core, srcObj);
+		return dropMoney(core, srcObj);
 
 	// only active objects can transfer money
 	if (srcObj->getType() != ObjectType::Core && srcObj->getType() != ObjectType::Unit)

--- a/src/game/Board.cpp
+++ b/src/game/Board.cpp
@@ -6,19 +6,6 @@ Board::Board(unsigned int grid_width, unsigned int grid_height)
 	objects_.reserve(grid_width * grid_height);
 }
 
-// @brief Adds object to board, if no object already at pos
-// @param `force` set to true will overwrite object if already present at pos
-// @return true if object was added sucessfully
-template <typename T>
-bool Board::addObject(const Object & object, bool force)
-{
-	static_assert(std::is_base_of<Object, T>::value, "T must be a subclass of Object");
-	unsigned int vecPos = gridPosToVecPos(object.getPosition());
-	if (vecPos < 0 || (objects_[vecPos] != nullptr && !force))
-		return false;
-	objects_[vecPos] = std::make_unique<T>(object);
-	return true;
-}
 // @return true if object was removed successfully
 bool Board::removeObjectById(unsigned int id)
 {

--- a/src/game/Board.cpp
+++ b/src/game/Board.cpp
@@ -59,20 +59,39 @@ Core *Board::getCoreByTeamId(unsigned int team_id) const
 			return (Core *)obj.get();
 	return nullptr;
 }
+Position Board::getObjectPositionById(unsigned int id) const
+{
+	for (unsigned int idx = 0; idx < objects_.size(); ++idx)
+	{
+		if (!objects_[idx]) 
+			continue;
+		if (objects_[idx]->getId() == id)
+			return vecPosToGridPos(idx);
+	}
+	return Position(-1, -1);
+}
 
 bool Board::moveObjectById(unsigned int id, const Position & newPos)
 {
-	Object *obj = getObjectById(id);
-	if (!obj || !newPos.isValid(grid_width_, grid_height_))
+	if (!newPos.isValid(grid_width_, grid_height_))
+		return false;
+	unsigned int destIdx = gridPosToVecPos(newPos);
+	if (destIdx >= objects_.size() || objects_[destIdx])
+		return false;
+	unsigned int srcIdx = std::numeric_limits<unsigned int>::max();
+	for (unsigned int idx = 0; idx < objects_.size(); ++idx)
+	{
+		if (objects_[idx] && objects_[idx]->getId() == id)
+		{
+			srcIdx = idx;
+			break;
+		}
+	}
+	if (srcIdx == std::numeric_limits<unsigned int>::max())
 		return false;
 
-	unsigned int vecPos = gridPosToVecPos(newPos);
-	if (vecPos < 0 || objects_[vecPos] != nullptr)
-		return false;
-
-	objects_[vecPos] = std::move(objects_[gridPosToVecPos(obj->getPosition())]);
-	objects_[gridPosToVecPos(obj->getPosition())] = nullptr;
-	obj->setPosition(newPos);
+	objects_[destIdx] = std::move(objects_[srcIdx]);
+	objects_[srcIdx] = nullptr;
 	return true;
 }
 

--- a/src/game/Board.cpp
+++ b/src/game/Board.cpp
@@ -9,12 +9,14 @@ Board::Board(unsigned int grid_width, unsigned int grid_height)
 // @brief Adds object to board, if no object already at pos
 // @param `force` set to true will overwrite object if already present at pos
 // @return true if object was added sucessfully
+template <typename T>
 bool Board::addObject(const Object & object, bool force)
 {
+	static_assert(std::is_base_of<Object, T>::value, "T must be a subclass of Object");
 	unsigned int vecPos = gridPosToVecPos(object.getPosition());
 	if (vecPos < 0 || (objects_[vecPos] != nullptr && !force))
 		return false;
-	objects_[vecPos] = std::make_unique<Object>(object);
+	objects_[vecPos] = std::make_unique<T>(object);
 	return true;
 }
 // @return true if object was removed successfully

--- a/src/game/Board.cpp
+++ b/src/game/Board.cpp
@@ -27,7 +27,7 @@ bool Board::removeObjectAtPos(const Position & pos)
 	if (!pos.isValid(grid_width_, grid_height_))
 		return false;
 	unsigned int vecPos = gridPosToVecPos(pos);
-	if (vecPos < 0 || objects_[vecPos] == nullptr)
+	if (vecPos > grid_height_ * grid_width_ || objects_[vecPos] == nullptr)
 		return false;
 	objects_[vecPos] = nullptr;
 	return true;
@@ -107,6 +107,6 @@ Position Board::vecPosToGridPos(unsigned int vecPos) const
 unsigned int Board::gridPosToVecPos(const Position & gridPos) const
 {
 	if (!gridPos.isValid(grid_width_, grid_height_))
-		return -1;
+		return -1; // purposeful overflow, max val to indicate invalidity
 	return gridPos.y * grid_width_ + gridPos.x;
 }

--- a/src/game/Board.cpp
+++ b/src/game/Board.cpp
@@ -1,0 +1,86 @@
+#include "Board.h"
+
+Board::Board(unsigned int grid_width, unsigned int grid_height)
+	: grid_width_(grid_width), grid_height_(grid_height)
+{
+	objects_.reserve(grid_width * grid_height);
+}
+
+// @brief Adds object to board, if no object already at pos
+// @param `force` set to true will overwrite object if already present at pos
+// @return true if object was added sucessfully
+bool Board::addObject(const Object & object, bool force)
+{
+	unsigned int vecPos = gridPosToVecPos(object.getPosition());
+	if (vecPos < 0 || (objects_[vecPos] != nullptr && !force))
+		return false;
+	objects_[vecPos] = std::make_unique<Object>(object);
+	return true;
+}
+// @return true if object was removed successfully
+bool Board::removeObjectById(unsigned int id)
+{
+	for (unsigned int i = 0; i < objects_.size(); ++i)
+	{
+		if (objects_[i] != nullptr && objects_[i]->getId() == id)
+		{
+			objects_[i].reset();
+			return true;
+		}
+	}
+	return false;
+}
+// @return true if object was removed successfully
+bool Board::removeObjectAtPos(const Position & pos)
+{
+	if (!pos.isValid(grid_width_, grid_height_))
+		return false;
+	unsigned int vecPos = gridPosToVecPos(pos);
+	if (vecPos < 0)
+		return false;
+	objects_[vecPos].reset();
+	return true;
+}
+
+// @return nullptr if no object with given id
+Object *Board::getObjectById(unsigned int id) const
+{
+	for (const auto &obj : objects_)
+		if (obj->getId() == id)
+			return obj.get();
+	return nullptr;
+}
+// @return nullptr if no object at given position
+Object *Board::getObjectAtPos(const Position & pos) const
+{
+	if (!pos.isValid(grid_width_, grid_height_))
+		return nullptr;
+	unsigned int vecPos = gridPosToVecPos(pos);
+	if (vecPos >= objects_.size())
+		return nullptr;
+	return objects_[vecPos].get();
+}
+// @return nullptr if no core with given team id
+Core *Board::getCoreByTeamId(unsigned int team_id) const
+{
+	for (const auto &obj : objects_)
+		if (obj->getType() == ObjectType::Core && ((Core *)obj.get())->getTeamId() == team_id)
+			return (Core *)obj.get();
+	return nullptr;
+}
+
+Position Board::vecPosToGridPos(unsigned int vecPos) const
+{
+	unsigned int x = vecPos % grid_width_;
+	unsigned int y = vecPos / grid_width_;
+	Position pos = Position(x, y);
+	if (!pos.isValid(grid_width_, grid_height_))
+		return Position(-1, -1);
+	return pos;
+}
+unsigned int Board::gridPosToVecPos(const Position & gridPos) const
+{
+	if (!gridPos.isValid(grid_width_, grid_height_))
+		return -1;
+	return gridPos.y * grid_width_ + gridPos.x;
+}

--- a/src/game/Board.cpp
+++ b/src/game/Board.cpp
@@ -37,8 +37,9 @@ bool Board::removeObjectAtPos(const Position & pos)
 Object *Board::getObjectById(unsigned int id) const
 {
 	for (const auto &obj : objects_)
-		if (obj->getId() == id)
-			return obj.get();
+		if (obj != nullptr)
+			if (obj->getId() == id)
+				return obj.get();
 	return nullptr;
 }
 // @return nullptr if no object at given position
@@ -55,8 +56,9 @@ Object *Board::getObjectAtPos(const Position & pos) const
 Core *Board::getCoreByTeamId(unsigned int team_id) const
 {
 	for (const auto &obj : objects_)
-		if (obj->getType() == ObjectType::Core && ((Core *)obj.get())->getTeamId() == team_id)
-			return (Core *)obj.get();
+		if (obj != nullptr)
+			if (obj->getType() == ObjectType::Core && ((Core *)obj.get())->getTeamId() == team_id)
+				return (Core *)obj.get();
 	return nullptr;
 }
 Position Board::getObjectPositionById(unsigned int id) const

--- a/src/game/Game.cpp
+++ b/src/game/Game.cpp
@@ -6,7 +6,7 @@ Game::Game(std::vector<unsigned int> team_ids)
 	std::vector<unsigned int> team_ids_double = team_ids;
 	shuffle_vector(team_ids_double); // randomly assign core positions to ensure fairness
 	for (unsigned int i = 0; i < team_ids.size(); ++i)
-		Board::instance().addObject<Core>(Core(Board::instance().getNextObjectId(), team_ids_double[i], Config::getCorePosition(i)), true);
+		Board::instance().addObject<Core>(Core(Board::instance().getNextObjectId(), team_ids_double[i]), Config::getCorePosition(i), true);
 	Config::instance().worldGenerator->generateWorld();
 	Logger::Log("Game created with " + std::to_string(team_ids.size()) + " teams.");
 }
@@ -120,10 +120,10 @@ void Game::tick(unsigned long long tick)
 		{
 			if (obj.getType() == ObjectType::Unit && ((Unit &)obj).getBalance() > 0)
 			{
-				Position objPos = obj.getPosition();
+				Position objPos = Board::instance().getObjectPositionById(obj.getId());
 				unsigned int unitBalance = ((Unit &)obj).getBalance();
 				Board::instance().removeObjectById(obj.getId());
-				Board::instance().addObject<Money>(Money(Board::instance().getNextObjectId(), objPos, unitBalance));
+				Board::instance().addObject<Money>(Money(Board::instance().getNextObjectId(), unitBalance), objPos);
 			}
 			else if (obj.getType() == ObjectType::Core)
 			{

--- a/src/game/Game.cpp
+++ b/src/game/Game.cpp
@@ -1,12 +1,12 @@
 #include "Game.h"
 
 Game::Game(std::vector<unsigned int> team_ids)
-	: teamCount_(team_ids.size()), nextObjectId_(1), board_(Config::getInstance().width, Config::getInstance().height)
+	: board_(Config::getInstance().width, Config::getInstance().height), teamCount_(team_ids.size()), nextObjectId_(1)
 {
 	std::vector<unsigned int> team_ids_double = team_ids;
 	shuffle_vector(team_ids_double); // randomly assign core positions to ensure fairness
 	for (unsigned int i = 0; i < team_ids.size(); ++i)
-		board_.addObject(Core(board_.getNextObjectId(), team_ids_double[i], Config::getCorePosition(i)), true);
+		board_.addObject<Core>(Core(board_.getNextObjectId(), team_ids_double[i], Config::getCorePosition(i)), true);
 	Config::getInstance().worldGenerator->generateWorld(this);
 	Logger::Log("Game created with " + std::to_string(team_ids.size()) + " teams.");
 }
@@ -123,7 +123,7 @@ void Game::tick(unsigned long long tick)
 				Position objPos = obj.getPosition();
 				unsigned int unitBalance = ((Unit &)obj).getBalance();
 				board_.removeObjectById(obj.getId());
-				board_.addObject(Money(board_.getNextObjectId(), objPos, unitBalance));
+				board_.addObject<Money>(Money(board_.getNextObjectId(), objPos, unitBalance));
 			}
 			else if (obj.getType() == ObjectType::Core)
 			{

--- a/src/game/StateEncoder.cpp
+++ b/src/game/StateEncoder.cpp
@@ -13,8 +13,8 @@ json Game::encodeState(std::vector<std::pair<Action *, Core &>> actions, unsigne
 
 		o["id"] = obj.getId();
 		o["type"] = (int)obj.getType();
-		o["x"] = obj.getPosition().x;
-		o["y"] = obj.getPosition().y;
+		o["x"] = Board::instance().getObjectPositionById(obj.getId()).x;
+		o["y"] = Board::instance().getObjectPositionById(obj.getId()).y;
 		o["hp"] = obj.getHP();
 
 		if (obj.getType() == ObjectType::Core)

--- a/src/game/StateEncoder.cpp
+++ b/src/game/StateEncoder.cpp
@@ -1,0 +1,57 @@
+#include "Game.h"
+
+json Game::encodeState(std::vector<std::pair<Action *, Core &>> actions, unsigned long long tick)
+{
+	json state;
+
+	state["tick"] = tick;
+
+	state["objects"] = json::array();
+	for (auto &objPtr : objects_)
+	{
+		Object &obj = *objPtr;
+
+		json o;
+
+		o["id"] = obj.getId();
+		o["type"] = (int)obj.getType();
+		o["x"] = obj.getPosition().x;
+		o["y"] = obj.getPosition().y;
+		o["hp"] = obj.getHP();
+
+		if (obj.getType() == ObjectType::Core)
+		{
+			o["teamId"] = ((Core &)obj).getTeamId();
+			o["balance"] = ((Core &)obj).getBalance();
+		}
+		if (obj.getType() == ObjectType::Unit)
+		{
+			o["teamId"] = ((Unit &)obj).getTeamId();
+			o["unit_type"] = ((Unit &)obj).getUnitType();
+			o["balance"] = ((Unit &)obj).getBalance();
+			o["nextMoveOpp"] = ((Unit &)obj).getNextMoveOpp();
+		}
+		if (obj.getType() == ObjectType::Resource || obj.getType() == ObjectType::Money)
+		{
+			o["balance"] = ((Resource &)obj).getBalance();
+		}
+		if (obj.getType() == ObjectType::Bomb)
+		{
+			o["countdown"] = ((Bomb &)obj).getCountdown();
+		}
+
+		state["objects"].push_back(o);
+	}
+
+	// append all actions that were executed without issues this turn
+	state["actions"] = json::array();
+	for (auto &action : actions)
+	{
+		if (action.first == nullptr)
+			continue;
+
+		state["actions"].push_back(action.first->encodeJSON());
+	}
+
+	return state;
+}

--- a/src/game/StateEncoder.cpp
+++ b/src/game/StateEncoder.cpp
@@ -7,7 +7,7 @@ json Game::encodeState(std::vector<std::pair<Action *, Core &>> actions, unsigne
 	state["tick"] = tick;
 
 	state["objects"] = json::array();
-	for (const Object & obj : board_)
+	for (const Object & obj : Board::instance())
 	{
 		json o;
 

--- a/src/game/StateEncoder.cpp
+++ b/src/game/StateEncoder.cpp
@@ -7,10 +7,8 @@ json Game::encodeState(std::vector<std::pair<Action *, Core &>> actions, unsigne
 	state["tick"] = tick;
 
 	state["objects"] = json::array();
-	for (auto &objPtr : objects_)
+	for (const Object & obj : board_)
 	{
-		Object &obj = *objPtr;
-
 		json o;
 
 		o["id"] = obj.getId();

--- a/src/game/Visualizer.cpp
+++ b/src/game/Visualizer.cpp
@@ -1,10 +1,11 @@
-#include "Game.h"
+#include "Visualizer.h"
+
 #include <iostream>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
-void Game::visualizeGameState(unsigned long long tick)
+void Visualizer::visualizeGameState(unsigned long long tick)
 {
 	std::cout << "Tick: " << tick << std::endl;
 
@@ -31,8 +32,8 @@ void Game::visualizeGameState(unsigned long long tick)
 
 	static const std::string EMPTY_CELL = u8"\u3000";
 
-	int H = Config::getInstance().height;
-	int W = Config::getInstance().width;
+	int H = Config::instance().height;
+	int W = Config::instance().width;
 
 	std::cout << u8"╔";
 	for (int x = 0; x < W; ++x)
@@ -45,7 +46,7 @@ void Game::visualizeGameState(unsigned long long tick)
 		for (int x = 0; x < W; ++x)
 		{
 			auto pos = Position(x, y);
-			Object *obj = board_.getObjectAtPos(pos);
+			Object *obj = Board::instance().getObjectAtPos(pos);
 			if (!obj)
 			{
 				std::cout << EMPTY_CELL;

--- a/src/game/Visualizer.cpp
+++ b/src/game/Visualizer.cpp
@@ -45,7 +45,7 @@ void Game::visualizeGameState(unsigned long long tick)
 		for (int x = 0; x < W; ++x)
 		{
 			auto pos = Position(x, y);
-			Object *obj = getObjectAtPos(pos);
+			Object *obj = board_.getObjectAtPos(pos);
 			if (!obj)
 			{
 				std::cout << EMPTY_CELL;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,12 +28,12 @@ int main(int argc, char *argv[])
 	}
 
 	Config::setConfigFilePath(argv[1]);
-	Config::getInstance(); // Would exit if config file is invalid
+	Config::instance(); // Would exit if config file is invalid & initializes config
 
 	ReplayEncoder::setReplaySaveFolder(argv[2]);
 	ReplayEncoder::verifyReplaySaveFolder();
 
-	if (argc - 3 > (int)Config::getInstance().corePositions.size())
+	if (argc - 3 > (int)Config::instance().corePositions.size())
 	{
 		Logger::Log(LogLevel::ERROR, "Too many team IDs for Core Locations specified.");
 		return 1;

--- a/src/object/Bomb.cpp
+++ b/src/object/Bomb.cpp
@@ -52,12 +52,3 @@ void Bomb::tick(unsigned long long tickCount, Game *game)
 		game->removeObjectById(this->getId());
 	}
 }
-
-std::unique_ptr<Object> &Bomb::clone(Position newPos, Game *game) const
-{
-	int nextObjId = game->getNextObjectId();
-	std::unique_ptr<Object> obj = std::make_unique<Bomb>(nextObjId, newPos);
-	obj->setHP(this->getHP());
-	game->getObjects().push_back(std::move(obj));
-	return game->getObjects().back();
-}

--- a/src/object/Bomb.cpp
+++ b/src/object/Bomb.cpp
@@ -1,7 +1,7 @@
 #include "Bomb.h"
 
-Bomb::Bomb(unsigned int id, Position pos)
-	: Object(id, pos, Config::instance().bombHp, ObjectType::Bomb), countdown_(Config::instance().bombCountdown) {}
+Bomb::Bomb(unsigned int id)
+	: Object(id, Config::instance().bombHp, ObjectType::Bomb), countdown_(Config::instance().bombCountdown) {}
 
 void Bomb::tick(unsigned long long tickCount)
 {
@@ -11,9 +11,10 @@ void Bomb::tick(unsigned long long tickCount)
 	if (countdown_ == 0)
 	{
 		int bombReach = Config::instance().bombReach;
+		Position bombPos = Board::instance().getObjectPositionById(this->getId());
 		for (int i = 0; i < bombReach; i++) // pos X
 		{
-			Object *obj = Board::instance().getObjectAtPos(Position(position_.x + i, position_.y));
+			Object *obj = Board::instance().getObjectAtPos(Position(bombPos.x + i, bombPos.y));
 			if (!obj)
 				continue;
 			if (obj->getType() == ObjectType::Wall)
@@ -22,7 +23,7 @@ void Bomb::tick(unsigned long long tickCount)
 		}
 		for (int i = 0; i < bombReach; i++) // pos Y
 		{
-			Object *obj = Board::instance().getObjectAtPos(Position(position_.x, position_.y + i));
+			Object *obj = Board::instance().getObjectAtPos(Position(bombPos.x, bombPos.y + i));
 			if (!obj)
 				continue;
 			if (obj->getType() == ObjectType::Wall)
@@ -31,7 +32,7 @@ void Bomb::tick(unsigned long long tickCount)
 		}
 		for (int i = 0; i < bombReach; i++) // neg X
 		{
-			Object *obj = Board::instance().getObjectAtPos(Position(position_.x - i, position_.y));
+			Object *obj = Board::instance().getObjectAtPos(Position(bombPos.x - i, bombPos.y));
 			if (!obj)
 				continue;
 			if (obj->getType() == ObjectType::Wall)
@@ -40,7 +41,7 @@ void Bomb::tick(unsigned long long tickCount)
 		}
 		for (int i = 0; i < bombReach; i++) // neg Y
 		{
-			Object *obj = Board::instance().getObjectAtPos(Position(position_.x, position_.y - i));
+			Object *obj = Board::instance().getObjectAtPos(Position(bombPos.x, bombPos.y - i));
 			if (!obj)
 				continue;
 			if (obj->getType() == ObjectType::Wall)

--- a/src/object/Bomb.cpp
+++ b/src/object/Bomb.cpp
@@ -15,7 +15,7 @@ void Bomb::tick(unsigned long long tickCount, Game *game)
 		int bombReach = Config::getInstance().bombReach;
 		for (int i = 0; i < bombReach; i++) // pos X
 		{
-			Object *obj = game->getObjectAtPos(Position(position_.x + i, position_.y));
+			Object *obj = game->board_.getObjectAtPos(Position(position_.x + i, position_.y));
 			if (!obj)
 				continue;
 			if (obj->getType() == ObjectType::Wall)
@@ -24,7 +24,7 @@ void Bomb::tick(unsigned long long tickCount, Game *game)
 		}
 		for (int i = 0; i < bombReach; i++) // pos Y
 		{
-			Object *obj = game->getObjectAtPos(Position(position_.x, position_.y + i));
+			Object *obj = game->board_.getObjectAtPos(Position(position_.x, position_.y + i));
 			if (!obj)
 				continue;
 			if (obj->getType() == ObjectType::Wall)
@@ -33,7 +33,7 @@ void Bomb::tick(unsigned long long tickCount, Game *game)
 		}
 		for (int i = 0; i < bombReach; i++) // neg X
 		{
-			Object *obj = game->getObjectAtPos(Position(position_.x - i, position_.y));
+			Object *obj = game->board_.getObjectAtPos(Position(position_.x - i, position_.y));
 			if (!obj)
 				continue;
 			if (obj->getType() == ObjectType::Wall)
@@ -42,13 +42,13 @@ void Bomb::tick(unsigned long long tickCount, Game *game)
 		}
 		for (int i = 0; i < bombReach; i++) // neg Y
 		{
-			Object *obj = game->getObjectAtPos(Position(position_.x, position_.y - i));
+			Object *obj = game->board_.getObjectAtPos(Position(position_.x, position_.y - i));
 			if (!obj)
 				continue;
 			if (obj->getType() == ObjectType::Wall)
 				break;
 			obj->setHP(obj->getHP() - Config::getInstance().bombDamage);
 		}
-		game->removeObjectById(this->getId());
+		game->board_.removeObjectById(this->getId());
 	}
 }

--- a/src/object/Bomb.cpp
+++ b/src/object/Bomb.cpp
@@ -1,54 +1,52 @@
 #include "Bomb.h"
 
-#include "Game.h"
-
 Bomb::Bomb(unsigned int id, Position pos)
-	: Object(id, pos, Config::getInstance().bombHp, ObjectType::Bomb), countdown_(Config::getInstance().bombCountdown) {}
+	: Object(id, pos, Config::instance().bombHp, ObjectType::Bomb), countdown_(Config::instance().bombCountdown) {}
 
-void Bomb::tick(unsigned long long tickCount, Game *game)
+void Bomb::tick(unsigned long long tickCount)
 {
 	(void)tickCount;
 	countdown_--;
 
 	if (countdown_ == 0)
 	{
-		int bombReach = Config::getInstance().bombReach;
+		int bombReach = Config::instance().bombReach;
 		for (int i = 0; i < bombReach; i++) // pos X
 		{
-			Object *obj = game->board_.getObjectAtPos(Position(position_.x + i, position_.y));
+			Object *obj = Board::instance().getObjectAtPos(Position(position_.x + i, position_.y));
 			if (!obj)
 				continue;
 			if (obj->getType() == ObjectType::Wall)
 				break;
-			obj->setHP(obj->getHP() - Config::getInstance().bombDamage);
+			obj->setHP(obj->getHP() - Config::instance().bombDamage);
 		}
 		for (int i = 0; i < bombReach; i++) // pos Y
 		{
-			Object *obj = game->board_.getObjectAtPos(Position(position_.x, position_.y + i));
+			Object *obj = Board::instance().getObjectAtPos(Position(position_.x, position_.y + i));
 			if (!obj)
 				continue;
 			if (obj->getType() == ObjectType::Wall)
 				break;
-			obj->setHP(obj->getHP() - Config::getInstance().bombDamage);
+			obj->setHP(obj->getHP() - Config::instance().bombDamage);
 		}
 		for (int i = 0; i < bombReach; i++) // neg X
 		{
-			Object *obj = game->board_.getObjectAtPos(Position(position_.x - i, position_.y));
+			Object *obj = Board::instance().getObjectAtPos(Position(position_.x - i, position_.y));
 			if (!obj)
 				continue;
 			if (obj->getType() == ObjectType::Wall)
 				break;
-			obj->setHP(obj->getHP() - Config::getInstance().bombDamage);
+			obj->setHP(obj->getHP() - Config::instance().bombDamage);
 		}
 		for (int i = 0; i < bombReach; i++) // neg Y
 		{
-			Object *obj = game->board_.getObjectAtPos(Position(position_.x, position_.y - i));
+			Object *obj = Board::instance().getObjectAtPos(Position(position_.x, position_.y - i));
 			if (!obj)
 				continue;
 			if (obj->getType() == ObjectType::Wall)
 				break;
-			obj->setHP(obj->getHP() - Config::getInstance().bombDamage);
+			obj->setHP(obj->getHP() - Config::instance().bombDamage);
 		}
-		game->board_.removeObjectById(this->getId());
+		Board::instance().removeObjectById(this->getId());
 	}
 }

--- a/src/object/Core.cpp
+++ b/src/object/Core.cpp
@@ -13,12 +13,3 @@ void Core::tick(unsigned long long tickCount, Game * game)
 	if (tickCount < Config::getInstance().idleIncomeTimeOut)
 		setBalance(getBalance() + Config::getInstance().idleIncome);
 }
-
-std::unique_ptr<Object> & Core::clone(Position newPos, Game * game) const
-{
-	(void)newPos;
-	(void)game;
-	assert(false && "Core::clone() should never be called for Core objects");
-	static std::unique_ptr<Object> dummy;
-	return dummy;
-}

--- a/src/object/Core.cpp
+++ b/src/object/Core.cpp
@@ -1,7 +1,7 @@
 #include "Core.h"
 
-Core::Core(unsigned int id, unsigned int teamId, Position pos)
-	: Object(id, pos, Config::instance().coreHp, ObjectType::Core), balance_(Config::instance().initialBalance), team_id_(teamId) {}
+Core::Core(unsigned int id, unsigned int teamId)
+	: Object(id, Config::instance().coreHp, ObjectType::Core), balance_(Config::instance().initialBalance), team_id_(teamId) {}
 
 void Core::tick(unsigned long long tickCount)
 {

--- a/src/object/Core.cpp
+++ b/src/object/Core.cpp
@@ -1,15 +1,10 @@
 #include "Core.h"
 
-#include "Game.h"
-
-#include <cassert>
-
 Core::Core(unsigned int id, unsigned int teamId, Position pos)
-	: Object(id, pos, Config::getInstance().coreHp, ObjectType::Core), balance_(Config::getInstance().initialBalance), team_id_(teamId) {}
+	: Object(id, pos, Config::instance().coreHp, ObjectType::Core), balance_(Config::instance().initialBalance), team_id_(teamId) {}
 
-void Core::tick(unsigned long long tickCount, Game * game)
+void Core::tick(unsigned long long tickCount)
 {
-	(void) game;
-	if (tickCount < Config::getInstance().idleIncomeTimeOut)
-		setBalance(getBalance() + Config::getInstance().idleIncome);
+	if (tickCount < Config::instance().idleIncomeTimeOut)
+		setBalance(getBalance() + Config::instance().idleIncome);
 }

--- a/src/object/Money.cpp
+++ b/src/object/Money.cpp
@@ -1,16 +1,13 @@
 #include "Money.h"
 
-#include "Game.h"
-
 Money::Money(unsigned int id, Position pos)
 	: Object(id, pos, 1, ObjectType::Money),
-	balance_(Config::getInstance().resourceIncome) {}
+	balance_(Config::instance().resourceIncome) {}
 Money::Money(unsigned int id, Position pos, unsigned int balance)
 	: Object(id, pos, 1, ObjectType::Money),
 	balance_(balance) {}
 
-void Money::tick(unsigned long long tickCount, Game * game)
+void Money::tick(unsigned long long tickCount)
 {
 	(void) tickCount;
-	(void) game;
 }

--- a/src/object/Money.cpp
+++ b/src/object/Money.cpp
@@ -1,10 +1,10 @@
 #include "Money.h"
 
-Money::Money(unsigned int id, Position pos)
-	: Object(id, pos, 1, ObjectType::Money),
+Money::Money(unsigned int id)
+	: Object(id, 1, ObjectType::Money),
 	balance_(Config::instance().resourceIncome) {}
-Money::Money(unsigned int id, Position pos, unsigned int balance)
-	: Object(id, pos, 1, ObjectType::Money),
+Money::Money(unsigned int id, unsigned int balance)
+	: Object(id, 1, ObjectType::Money),
 	balance_(balance) {}
 
 void Money::tick(unsigned long long tickCount)

--- a/src/object/Money.cpp
+++ b/src/object/Money.cpp
@@ -14,12 +14,3 @@ void Money::tick(unsigned long long tickCount, Game * game)
 	(void) tickCount;
 	(void) game;
 }
-
-std::unique_ptr<Object> & Money::clone(Position newPos, Game * game) const
-{
-	int nextObjId = game->getNextObjectId();
-	std::unique_ptr<Object> obj = std::make_unique<Money>(nextObjId, newPos, balance_);
-	obj->setHP(this->getHP());
-	game->getObjects().push_back(std::move(obj));
-	return game->getObjects().back();
-}

--- a/src/object/Resource.cpp
+++ b/src/object/Resource.cpp
@@ -39,12 +39,3 @@ void Resource::tick(unsigned long long tickCount, Game *game)
 	(void)tickCount;
 	(void)game;
 }
-
-std::unique_ptr<Object> &Resource::clone(Position newPos, Game *game) const
-{
-	int nextObjId = game->getNextObjectId();
-	std::unique_ptr<Object> obj = std::make_unique<Resource>(nextObjId, newPos, balance_);
-	obj->setHP(this->getHP());
-	game->getObjects().push_back(std::move(obj));
-	return game->getObjects().back();
-}

--- a/src/object/Resource.cpp
+++ b/src/object/Resource.cpp
@@ -1,18 +1,16 @@
 #include "Resource.h"
 
-#include "Game.h"
-
 Resource::Resource(unsigned int id, Position pos)
-	: Object(id, pos, Config::getInstance().resourceHp, ObjectType::Resource),
-	  balance_(Config::getInstance().resourceIncome) {}
+	: Object(id, pos, Config::instance().resourceHp, ObjectType::Resource),
+	  balance_(Config::instance().resourceIncome) {}
 Resource::Resource(unsigned int id, Position pos, unsigned int balance)
-	: Object(id, pos, static_cast<unsigned int>(std::round(double(balance) / Config::getInstance().resourceIncome * Config::getInstance().resourceHp)),
+	: Object(id, pos, static_cast<unsigned int>(std::round(double(balance) / Config::instance().resourceIncome * Config::instance().resourceHp)),
 			 ObjectType::Resource),
 	  balance_(balance) {}
 
 void Resource::getMined(Unit *miner)
 {
-	unsigned int damage = Config::getInstance().units[miner->getUnitType()].damageResource;
+	unsigned int damage = Config::instance().units[miner->getUnitType()].damageResource;
 	if ((int)damage > hp_)
 		damage = hp_;
 
@@ -34,8 +32,7 @@ void Resource::getMined(Unit *miner)
 	miner->addBalance(reward);
 }
 
-void Resource::tick(unsigned long long tickCount, Game *game)
+void Resource::tick(unsigned long long tickCount)
 {
 	(void)tickCount;
-	(void)game;
 }

--- a/src/object/Resource.cpp
+++ b/src/object/Resource.cpp
@@ -1,10 +1,10 @@
 #include "Resource.h"
 
-Resource::Resource(unsigned int id, Position pos)
-	: Object(id, pos, Config::instance().resourceHp, ObjectType::Resource),
+Resource::Resource(unsigned int id)
+	: Object(id, Config::instance().resourceHp, ObjectType::Resource),
 	  balance_(Config::instance().resourceIncome) {}
-Resource::Resource(unsigned int id, Position pos, unsigned int balance)
-	: Object(id, pos, static_cast<unsigned int>(std::round(double(balance) / Config::instance().resourceIncome * Config::instance().resourceHp)),
+Resource::Resource(unsigned int id, unsigned int balance)
+	: Object(id, static_cast<unsigned int>(std::round(double(balance) / Config::instance().resourceIncome * Config::instance().resourceHp)),
 			 ObjectType::Resource),
 	  balance_(balance) {}
 

--- a/src/object/Unit.cpp
+++ b/src/object/Unit.cpp
@@ -1,29 +1,24 @@
 #include "Unit.h"
 
-#include "Game.h"
-
-#include <cassert>
-
 Unit::Unit(unsigned int id, unsigned int teamId, Position pos, unsigned int unit_type)
-	: Object(id, pos, Config::getInstance().units[unit_type].hp, ObjectType::Unit), unit_type_(unit_type), team_id_(teamId), balance_(0)
+	: Object(id, pos, Config::instance().units[unit_type].hp, ObjectType::Unit), unit_type_(unit_type), team_id_(teamId), balance_(0)
 {
 	resetNextMoveOpp();
 }
 
-void Unit::tick(unsigned long long tickCount, Game *game)
+void Unit::tick(unsigned long long tickCount)
 {
 	(void)tickCount;
-	(void)game;
 	if (next_move_opp_ > 0)
 		next_move_opp_--;
 }
 
 unsigned int Unit::calcNextMovementOpp()
 {
-	unsigned int baseSpeed = Config::getInstance().units[unit_type_].speed;
-	unsigned int minSpeed = Config::getInstance().units[unit_type_].minSpeed;
+	unsigned int baseSpeed = Config::instance().units[unit_type_].speed;
+	unsigned int minSpeed = Config::instance().units[unit_type_].minSpeed;
 
-	float resourcePart = balance_ / (Config::getInstance().resourceIncome / 4);
+	float resourcePart = balance_ / (Config::instance().resourceIncome / 4);
 	if (resourcePart < 1)
 		resourcePart = 1; // up to 1/4 resource balance does not slow down
 

--- a/src/object/Unit.cpp
+++ b/src/object/Unit.cpp
@@ -34,12 +34,3 @@ unsigned int Unit::calcNextMovementOpp()
 
 	return speed;
 }
-
-std::unique_ptr<Object> &Unit::clone(Position newPos, Game *game) const
-{
-	(void)newPos;
-	(void)game;
-	assert(false && "Unit::clone() should never be called for Core objects");
-	static std::unique_ptr<Object> dummy;
-	return dummy;
-}

--- a/src/object/Unit.cpp
+++ b/src/object/Unit.cpp
@@ -1,7 +1,7 @@
 #include "Unit.h"
 
-Unit::Unit(unsigned int id, unsigned int teamId, Position pos, unsigned int unit_type)
-	: Object(id, pos, Config::instance().units[unit_type].hp, ObjectType::Unit), unit_type_(unit_type), team_id_(teamId), balance_(0)
+Unit::Unit(unsigned int id, unsigned int teamId, unsigned int unit_type)
+	: Object(id, Config::instance().units[unit_type].hp, ObjectType::Unit), unit_type_(unit_type), team_id_(teamId), balance_(0)
 {
 	resetNextMoveOpp();
 }

--- a/src/object/Wall.cpp
+++ b/src/object/Wall.cpp
@@ -10,12 +10,3 @@ void Wall::tick(unsigned long long tickCount, Game * game)
 	(void) tickCount;
 	(void) game;
 }
-
-std::unique_ptr<Object> & Wall::clone(Position newPos, Game * game) const
-{
-	int nextObjId = game->getNextObjectId();
-	std::unique_ptr<Object> obj = std::make_unique<Wall>(nextObjId, newPos);
-	obj->setHP(this->getHP());
-	game->getObjects().push_back(std::move(obj));
-	return game->getObjects().back();
-}

--- a/src/object/Wall.cpp
+++ b/src/object/Wall.cpp
@@ -1,12 +1,9 @@
 #include "Wall.h"
 
-#include "Game.h"
-
 Wall::Wall(unsigned int id, Position pos)
-	: Object(id, pos, Config::getInstance().wallHp, ObjectType::Wall) {}
+	: Object(id, pos, Config::instance().wallHp, ObjectType::Wall) {}
 
-void Wall::tick(unsigned long long tickCount, Game * game)
+void Wall::tick(unsigned long long tickCount)
 {
 	(void) tickCount;
-	(void) game;
 }

--- a/src/object/Wall.cpp
+++ b/src/object/Wall.cpp
@@ -1,7 +1,7 @@
 #include "Wall.h"
 
-Wall::Wall(unsigned int id, Position pos)
-	: Object(id, pos, Config::instance().wallHp, ObjectType::Wall) {}
+Wall::Wall(unsigned int id)
+	: Object(id, Config::instance().wallHp, ObjectType::Wall) {}
 
 void Wall::tick(unsigned long long tickCount)
 {

--- a/src/utils/flood_fill.cpp
+++ b/src/utils/flood_fill.cpp
@@ -1,10 +1,10 @@
 #include "Utils.h"
 
-Position findFirstEmptyGridCell(Game* game, Position startPos) // bfs / flood fill
+Position findFirstEmptyGridCell(Position startPos) // bfs / flood fill
 {
-	Position errorPos = {static_cast<int>(Config::getInstance().width), static_cast<int>(Config::getInstance().height)};
-	const int width  = Config::getInstance().width;
-	const int height = Config::getInstance().height;
+	Position errorPos = {static_cast<int>(Config::instance().width), static_cast<int>(Config::instance().height)};
+	const int width  = Config::instance().width;
+	const int height = Config::instance().height;
 	
 	if ((int)startPos.x < 0 || (int)startPos.x >= width || (int)startPos.y < 0 || (int)startPos.y >= height)
 		return errorPos;
@@ -26,7 +26,7 @@ Position findFirstEmptyGridCell(Game* game, Position startPos) // bfs / flood fi
 		if ((int)cur.x < 0 || (int)cur.x >= width || (int)cur.y < 0 || (int)cur.y >= height)
 			continue;
 
-		if (game->board_.getObjectAtPos(cur) == nullptr)
+		if (Board::instance().getObjectAtPos(cur) == nullptr)
 			return cur;
 
 		for (int i = 0; i < 4; i++)

--- a/src/utils/flood_fill.cpp
+++ b/src/utils/flood_fill.cpp
@@ -26,7 +26,7 @@ Position findFirstEmptyGridCell(Game* game, Position startPos) // bfs / flood fi
 		if ((int)cur.x < 0 || (int)cur.x >= width || (int)cur.y < 0 || (int)cur.y >= height)
 			continue;
 
-		if (game->getObjectAtPos(cur) == nullptr)
+		if (game->board_.getObjectAtPos(cur) == nullptr)
 			return cur;
 
 		for (int i = 0; i < 4; i++)


### PR DESCRIPTION
Previously, every object had a position field and they were all stored in a random order in a 1d array. Error prone system:

- Potential desync between different objects causing multiple objects at one position
- Units walking off the grid
- Annoying that so much logic that has little to do with each other is in one file (e.g. ticking and core getters)

Pull request introduces singleton board class seperate from game logic that serves as single source of truth for object positioning. Also, we don't have to pass the Game class as an argument around the entire program anymore.

- Board objects can be traversed safely via built-in Iterator that skips over uninitialized objects / empty grid spots.
- StateEncoding and Terminal Visualization logic seperated into own classes seperate of game.