### PR TITLE
cleaner game over handling #16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CXX := clang++
 
-CXXFLAGS := -std=c++17 -Wall -Wextra -Werror -pthread -MMD -MP -g -gdwarf-4
+CXXFLAGS := -std=c++17 -Wall -Wextra -Werror -pthread -MMD -MP -g -gdwarf-4 -fsanitize=address
 
 LDFLAGS := -pthread
 

--- a/inc/game/Board.h
+++ b/inc/game/Board.h
@@ -39,6 +39,7 @@ class Board
 		Object			*getObjectAtPos(const Position & pos) const;
 		Core			*getCoreByTeamId(unsigned int team_id) const;
 		Position		getObjectPositionById(unsigned int id) const;
+		int				getCoreCount();
 
 		bool			moveObjectById(unsigned int id, const Position & newPos);
 

--- a/inc/game/Game.h
+++ b/inc/game/Game.h
@@ -39,7 +39,6 @@ class Game
 		void sendState(std::vector<std::pair<std::unique_ptr<Action>, Core &>> &actions, unsigned long long tick);
 		void sendConfig();
 
-		unsigned int teamCount_;
 		unsigned int nextObjectId_;
 		std::vector<std::unique_ptr<Bridge>> bridges_;
 

--- a/src/game/Board.cpp
+++ b/src/game/Board.cpp
@@ -72,6 +72,16 @@ Position Board::getObjectPositionById(unsigned int id) const
 	}
 	return Position(-1, -1);
 }
+int Board::getCoreCount()
+{
+	int count = 0;
+	for (const auto &obj : objects_)
+	{
+		if (obj && obj->getType() == ObjectType::Core)
+			++count;
+	}
+	return count;
+}
 
 bool Board::moveObjectById(unsigned int id, const Position & newPos)
 {

--- a/src/net/Bridge.cpp
+++ b/src/net/Bridge.cpp
@@ -82,7 +82,7 @@ void Bridge::readLoop()
 		while (!disconnected_)
 		{
 			ssize_t n = ::read(socket_fd_, buffer, buffer_size);
-			if (n <= 0)
+			if (n < 0)
 			{
 				if (errno == EAGAIN || errno == EWOULDBLOCK)
 				{
@@ -95,6 +95,12 @@ void Bridge::readLoop()
 					disconnected_ = true;
 					break;
 				}
+			}
+			else if (n == 0)
+			{
+				Logger::Log(LogLevel::WARNING, "Connection closed by peer. Disconnecting " + std::to_string(team_id_) + ".");
+				disconnected_ = true;
+				break;
 			}
 			data.append(buffer, n);
 


### PR DESCRIPTION
Currently clients and server just kinda print errors and accept defeat. Now they exit cleanly and print whether one has won or lost.
This only works with the connection branch https://github.com/42core-team/connection/tree/game_over_handling. They should be merged at the same time.