### PR TITLE
34 hard timeout

### DIFF
--- a/hard.config.json
+++ b/hard.config.json
@@ -2,6 +2,7 @@
   "width": 30,
   "height": 30,
   "tickRate": 5,
+  "timeout": 3000,
   "idleIncome": 0,
   "idleIncomeTimeOut": 600,
   "resourceHp": 50,

--- a/inc/config/Config.h
+++ b/inc/config/Config.h
@@ -22,6 +22,7 @@ struct GameConfig
 	unsigned int width;
 	unsigned int height;
 	unsigned int tickRate; // ticks per second
+	unsigned int timeout;
 
 	unsigned int idleIncome;		// idle income per tick
 	unsigned int idleIncomeTimeOut; // idle income duration in ticks

--- a/inc/game/Game.h
+++ b/inc/game/Game.h
@@ -44,6 +44,8 @@ class Game
 		unsigned int nextObjectId_;
 		std::vector<std::unique_ptr<Bridge>> bridges_;
 
+		std::mt19937 rng_;
+
 		ReplayEncoder replayEncoder_;
 };
 

--- a/inc/game/Game.h
+++ b/inc/game/Game.h
@@ -35,6 +35,8 @@ class Game
 	private:
 		void tick(unsigned long long tick);
 
+		void handleTimeout();
+
 		json encodeState(std::vector<std::pair<std::unique_ptr<Action>, Core &>> &actions, unsigned long long tick);
 		void sendState(std::vector<std::pair<std::unique_ptr<Action>, Core &>> &actions, unsigned long long tick);
 		void sendConfig();

--- a/inc/game/Game.h
+++ b/inc/game/Game.h
@@ -35,7 +35,7 @@ class Game
 	private:
 		void tick(unsigned long long tick);
 
-		void handleTimeout();
+		void killWorstPlayerOnTimeout();
 
 		json encodeState(std::vector<std::pair<std::unique_ptr<Action>, Core &>> &actions, unsigned long long tick);
 		void sendState(std::vector<std::pair<std::unique_ptr<Action>, Core &>> &actions, unsigned long long tick);

--- a/inc/game/ReplayEncoder.h
+++ b/inc/game/ReplayEncoder.h
@@ -14,6 +14,14 @@ typedef struct team_data_s {
 	unsigned int place; // 0 = won
 }	team_data_t;
 
+typedef enum game_end_reason_e {
+	GER_DEFEAT,
+	GER_CORE_HP,
+	GER_UNIT_HP,
+	GER_MONEY_IN_CORE,
+	GER_RANDOM
+}	game_end_reason_t;
+
 class ReplayEncoder
 {
 public:
@@ -22,6 +30,7 @@ public:
 
 	void addTickState(const json& state);
 	void addTeamScore(unsigned int teamId, const std::string& teamName, unsigned int place);
+	void setGameEndReason(game_end_reason_t reason) { gameEndReason_ = reason; }
 	void includeConfig(json& config);
 	void saveReplay() const;
 
@@ -40,6 +49,7 @@ private:
 	std::unordered_map<int, json> previousObjects_;
 	unsigned long long lastTickCount_;
 	std::vector<team_data_t> teamData_;
+	game_end_reason_t gameEndReason_ = GER_DEFEAT;
 
 	static std::string replaySaveFolder_;
 };

--- a/inc/game/ReplayEncoder.h
+++ b/inc/game/ReplayEncoder.h
@@ -8,6 +8,12 @@ using json = nlohmann::ordered_json;
 
 #include <fstream>
 
+typedef struct team_data_s {
+	unsigned int teamId;
+	std::string teamName;
+	unsigned int place; // 0 = won
+}	team_data_t;
+
 class ReplayEncoder
 {
 public:
@@ -15,6 +21,7 @@ public:
 	~ReplayEncoder() = default;
 
 	void addTickState(const json& state);
+	void addTeamScore(unsigned int teamId, const std::string& teamName, unsigned int place);
 	void includeConfig(json& config);
 	void saveReplay() const;
 
@@ -25,12 +32,14 @@ private:
 	json diffObjects(const json& currentObjects);
 	json diffObject(const json& currentObj, const json& previousObj);
 
+	json encodeMiscSection() const;
+
 	json ticks_;
 	json config_;
 
 	std::unordered_map<int, json> previousObjects_;
-
 	unsigned long long lastTickCount_;
+	std::vector<team_data_t> teamData_;
 
 	static std::string replaySaveFolder_;
 };

--- a/inc/net/Bridge.h
+++ b/inc/net/Bridge.h
@@ -29,12 +29,16 @@ class Bridge
 		unsigned int getTeamId() const { return team_id_; }
 		void setTeamId(unsigned int teamId) { team_id_ = teamId; }
 
+		const std::string& getTeamName() const { return team_name_; }
+		void setTeamName(const std::string& teamName) { team_name_ = teamName; }
+
 	private:
 		void readLoop();
 		void writeLoop();
 
 		int socket_fd_;
 		unsigned int team_id_;
+		std::string team_name_;
 		std::thread readThread_;
 		std::thread writeThread_;
 

--- a/soft.config.json
+++ b/soft.config.json
@@ -2,6 +2,7 @@
   "width": 25,
   "height": 25,
   "tickRate": 5,
+  "timeout": 3000,
   "idleIncome": 1,
   "idleIncomeTimeOut": 600,
   "resourceHp": 50,

--- a/src/Config/Config.cpp
+++ b/src/Config/Config.cpp
@@ -21,6 +21,7 @@ GameConfig parseConfig()
 	config.width = j.value("width", 25);
 	config.height = j.value("height", 25);
 	config.tickRate = j.value("tickRate", 5);
+	config.timeout = j.value("timeout", 3000);
 	config.idleIncome = j.value("idleIncome", 1);
 	config.idleIncomeTimeOut = j.value("idleIncomeTimeOut", 600);
 	config.resourceHp = j.value("resourceHp", 50);

--- a/src/game/Board.cpp
+++ b/src/game/Board.cpp
@@ -77,7 +77,7 @@ int Board::getCoreCount()
 	int count = 0;
 	for (const auto &obj : objects_)
 	{
-		if (obj && obj->getType() == ObjectType::Core)
+		if (obj && obj->getType() == ObjectType::Core && obj->getHP() > 0)
 			++count;
 	}
 	return count;

--- a/src/game/Game.cpp
+++ b/src/game/Game.cpp
@@ -219,6 +219,7 @@ void Game::killWorstPlayerOnTimeout()
 			{
 				minUnitHp = totalUnitHp;
 				minUnitHpCore = &core;
+				tie = false;
 			}
 			else if (totalUnitHp == minUnitHp && minUnitHpCore)
 			{
@@ -237,17 +238,21 @@ void Game::killWorstPlayerOnTimeout()
 	// 3. Random pick
 	{
 		unsigned int remainingCores = Board::instance().getCoreCount();
-		unsigned int randomIndex = rand() % remainingCores;
+		std::uniform_int_distribution<unsigned> dist(0, remainingCores - 1);
+		unsigned int randomIndex = dist(rng_);
 		Object * randomCore = nullptr;
 		for (auto& obj : Board::instance())
 		{
-			if (randomIndex == 0)
-			{
-				randomCore = &obj;
-				break;
-			}
 			if (obj.getType() == ObjectType::Core && obj.getHP() > 0)
-				randomIndex--;
+			{
+				if (randomIndex == 0)
+				{
+					randomCore = &obj;
+					break;
+				}
+				else
+					randomIndex--;
+			}
 		}
 		if (randomCore)
 		{

--- a/src/game/Game.cpp
+++ b/src/game/Game.cpp
@@ -253,44 +253,6 @@ void Game::handleTimeout()
 	if (Board::instance().getCoreCount() <= 1)
 		return;
 
-	// if there are still cores left, pick core with least money in core total
-	unsigned int minMoneyInCore = std::numeric_limits<unsigned int>::max();
-	unsigned int teamIdWithMinMoneyInCore = std::numeric_limits<unsigned int>::max();
-	for (auto& bridge : bridges_)
-	{
-		unsigned int teamId = bridge->getTeamId();
-		unsigned int totalMoneyInCore = 0;
-
-		for (auto& obj : Board::instance())
-			if (obj.getType() == ObjectType::Core && ((Core&)obj).getTeamId() == teamId)
-				totalMoneyInCore += ((Core&)obj).getBalance();
-
-		if (totalMoneyInCore < minMoneyInCore)
-		{
-			minMoneyInCore = totalMoneyInCore;
-			teamIdWithMinMoneyInCore = teamId;
-		}
-	}
-	if (teamIdWithMinMoneyInCore != std::numeric_limits<unsigned int>::max())
-	{
-		Logger::Log("Killing core of team " + std::to_string(teamIdWithMinMoneyInCore) + " due to timeout.");
-		replayEncoder_.setGameEndReason(GER_MONEY_IN_CORE);
-		for (auto& bridge : bridges_)
-		{
-			if (bridge->getTeamId() == teamIdWithMinMoneyInCore)
-			{
-				replayEncoder_.addTeamScore(bridge->getTeamId(), bridge->getTeamName(), Board::instance().getCoreCount() - 1);
-				bridges_.erase(std::remove(bridges_.begin(), bridges_.end(), bridge), bridges_.end());
-				break;
-			}
-		}
-		for (auto& obj : Board::instance())
-			if (obj.getType() == ObjectType::Core && ((Core&)obj).getTeamId() == teamIdWithMinMoneyInCore)
-				((Core&)obj).setHP(0);
-	}
-	if (Board::instance().getCoreCount() <= 1)
-		return;
-
 	// determine winner randomly
 	replayEncoder_.setGameEndReason(GER_RANDOM);
 	while (Board::instance().getCoreCount() > 1)

--- a/src/game/Game.cpp
+++ b/src/game/Game.cpp
@@ -54,6 +54,16 @@ void Game::run()
 		tickCount++;
 	}
 
+	// determine winner
+	for (const auto& bridge : bridges_)
+	{
+		if (!bridge->isDisconnected())
+		{
+			replayEncoder_.addTeamScore(bridge->getTeamId(), bridge->getTeamName(), 0); // 0 = won
+			Logger::Log("Team " + std::to_string(bridge->getTeamId()) + " (" + bridge->getTeamName() + ") won the game!");
+		}
+	}
+
 	Logger::Log("Game ended! Saving replay...");
 	json config = Config::encodeConfig();
 	replayEncoder_.includeConfig(config);
@@ -143,6 +153,7 @@ void Game::tick(unsigned long long tick)
 			{
 				if (!bridge->isDisconnected() && bridge->getTeamId() == core.getTeamId())
 				{
+					replayEncoder_.addTeamScore(bridge->getTeamId(), bridge->getTeamName(), Board::instance().getCoreCount() - 1);
 					bridges_.erase(std::remove(bridges_.begin(), bridges_.end(), bridge), bridges_.end());
 					break;
 				}

--- a/src/game/ReplayEncoder.cpp
+++ b/src/game/ReplayEncoder.cpp
@@ -139,6 +139,7 @@ json ReplayEncoder::encodeMiscSection() const
 		teamJson["place"] = team.place;
 		miscSection["team_results"].push_back(teamJson);
 	}
+	miscSection["game_end_reason"] = static_cast<int>(gameEndReason_);
 	return miscSection;
 }
 

--- a/src/game/ReplayEncoder.cpp
+++ b/src/game/ReplayEncoder.cpp
@@ -94,6 +94,16 @@ void ReplayEncoder::addTickState(const json &state)
 	lastTickCount_ = tick;
 }
 
+void ReplayEncoder::addTeamScore(unsigned int teamId, const std::string &teamName, unsigned int place)
+{
+	team_data_t teamData;
+	teamData.teamId = teamId;
+	teamData.teamName = teamName;
+	teamData.place = place;
+
+	teamData_.push_back(teamData);
+}
+
 void ReplayEncoder::includeConfig(json &config)
 {
 	config_ = config;
@@ -117,6 +127,21 @@ void ReplayEncoder::verifyReplaySaveFolder()
 	}
 }
 
+json ReplayEncoder::encodeMiscSection() const
+{
+	json miscSection;
+	miscSection["team_results"] = json::array();
+	for (const auto &team : teamData_)
+	{
+		json teamJson;
+		teamJson["id"] = team.teamId;
+		teamJson["name"] = team.teamName;
+		teamJson["place"] = team.place;
+		miscSection["team_results"].push_back(teamJson);
+	}
+	return miscSection;
+}
+
 void ReplayEncoder::saveReplay() const
 {
 	if (replaySaveFolder_.empty())
@@ -126,6 +151,7 @@ void ReplayEncoder::saveReplay() const
 	}
 
 	json replayData;
+	replayData["misc"] = encodeMiscSection();
 	replayData["ticks"] = ticks_;
 	replayData["config"] = config_;
 	replayData["full_tick_amount"] = lastTickCount_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -123,7 +123,9 @@ int main(int argc, char *argv[])
 			continue;
 		}
 		unsigned int teamId = loginMessage["id"];
+		std::string teamName = loginMessage["name"];
 		bridge->setTeamId(teamId);
+		bridge->setTeamName(teamName);
 
 		if (std::find(expectedTeamIds.begin(), expectedTeamIds.end(), teamId) == expectedTeamIds.end())
 		{


### PR DESCRIPTION
Functional timeout changeable via config with fair logic to pick a clear winner, based on, in this order:

1. More Core HP
2. More overall Unit HP
3. Random choice

This way, we can stop games from going too long and discourage boring non-risk-taking hyper-defensive strategies.

After timeout has been reached, the worst alive team will be determined and killed every tick.

Branch also adds a misc section into replay format, which specified team ids, names, and the place each team took in the game, as well as the reason the final player won (defeated the others / more core hp / more unit hp / random).