### PR TITLE
feat(server): add dedicated class for listening server

### DIFF
--- a/inc/net/Server.h
+++ b/inc/net/Server.h
@@ -1,0 +1,26 @@
+#ifndef SERVER_H
+#define SERVER_H
+
+#include <string>
+
+class Server {
+
+  const int sock_fd;
+
+ public:
+  // Constructor
+  explicit Server(int port = 4242);
+  // Deconstructor
+  ~Server();
+
+  // Delete all other, because we only want a single server
+  Server(const Server& other) = delete;
+  Server(Server&& other) = delete;
+  Server& operator=(const Server& other) = delete;
+  Server& operator=(Server&& other) = delete;
+
+  int getSock() const;
+  int acceptClient(std::string& name) const;
+};
+
+#endif

--- a/src/net/Server.cpp
+++ b/src/net/Server.cpp
@@ -1,0 +1,77 @@
+#include <arpa/inet.h>
+#include <asm-generic/socket.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "Logger.h"
+#include "Server.h"
+
+Server::Server(int port) : sock_fd(socket(AF_INET, SOCK_STREAM, 0)) {
+  if (sock_fd < 0) {
+    Logger::Log(LogLevel::ERROR, "Could not create socket.");
+    std::runtime_error("Socket is mandatory to work.");
+  }
+
+  int opt = 1;
+  if (setsockopt(sock_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0) {
+    Logger::Log(LogLevel::ERROR, "Could not set socket option.");
+    close(sock_fd);
+    std::runtime_error("Socket is mandatory to work.");
+  }
+
+  struct sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = INADDR_ANY;
+  addr.sin_port = htons(port);
+
+  if (bind(sock_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+    Logger::Log(LogLevel::ERROR, "Could not bind on socket.");
+    close(sock_fd);
+    std::runtime_error("Socket is mandatory to work.");
+  }
+
+  if (listen(sock_fd, SOMAXCONN) < 0) {
+    Logger::Log(LogLevel::ERROR, "Could not listen on socket.");
+    close(sock_fd);
+    std::runtime_error("Socket is mandatory to work.");
+  }
+
+  Logger::Log("Server listening on port " + std::to_string(port) + "...");
+}
+
+Server::~Server() {
+  close(sock_fd);
+}
+
+/**
+ * getSock() - Return the listening socket
+ *
+ * @return sock_fd
+ */
+int Server::getSock() const {
+  return sock_fd;
+}
+
+/**
+ * acceptClient() - accept a client for a tcp connection
+ * @param name Out parameter to write the address of the connection into.
+ *
+ * @return client_fd Successful accepting a client connection.
+ * @return -1  On error.
+ */
+int Server::acceptClient(std::string& name) const {
+  sockaddr_in client_addr;
+  socklen_t client_len = sizeof(client_addr);
+  int client_fd = accept(sock_fd, reinterpret_cast<sockaddr*>(&client_addr), &client_len);
+
+  if (client_fd < 0) {
+    Logger::Log(LogLevel::ERROR, "Could not accept client.");
+    return -1;
+  }
+
+  // fill the out-parameter name with the client connection address
+  name = std::string(inet_ntoa(client_addr.sin_addr));
+
+  return client_fd;
+}


### PR DESCRIPTION
Commit for wrapping the sock_fd for the listening server. When initializing the server,
it throws a runtime_error and therefore exits the program.

Also removed the close(socket_fd) call in main.cpp, because this is handled by the socket destructor.

Move 'Listening to Port' into the server + also add the port which can be individualized.

closes #27 