### PR TITLE
fix(includes): remove unnecessary includes

### DIFF
--- a/src/net/Server.cpp
+++ b/src/net/Server.cpp
@@ -1,6 +1,4 @@
 #include <arpa/inet.h>
-#include <asm-generic/socket.h>
-#include <netinet/in.h>
 #include <sys/socket.h>
 #include <unistd.h>
 


### PR DESCRIPTION
Remove unnecessary include files which also failed during Dockerimage creation.

closes #45 