### PR TITLE
Fix core switching mid-game

### DIFF
--- a/inc/game/Game.h
+++ b/inc/game/Game.h
@@ -37,8 +37,8 @@ class Game
 
 		void killWorstPlayerOnTimeout();
 
-		json encodeState(std::vector<std::pair<std::unique_ptr<Action>, Core &>> &actions, unsigned long long tick);
-		void sendState(std::vector<std::pair<std::unique_ptr<Action>, Core &>> &actions, unsigned long long tick);
+		json encodeState(std::vector<std::pair<std::unique_ptr<Action>, Core *>> &actions, unsigned long long tick);
+		void sendState(std::vector<std::pair<std::unique_ptr<Action>, Core *>> &actions, unsigned long long tick);
 		void sendConfig();
 
 		unsigned int nextObjectId_;

--- a/src/game/Game.cpp
+++ b/src/game/Game.cpp
@@ -74,7 +74,7 @@ void Game::tick(unsigned long long tick)
 {
 	// 1. COMPUTE ACTIONS
 
-	std::vector<std::pair<std::unique_ptr<Action>, Core &>> actions; // action, team id
+	std::vector<std::pair<std::unique_ptr<Action>, Core *>> actions; // action, team id
 
 	for (auto& bridge : bridges_)
 	{
@@ -91,16 +91,16 @@ void Game::tick(unsigned long long tick)
 		std::vector<std::unique_ptr<Action>> clientActions = Action::parseActions(msg);
 
 		for (auto& action : clientActions)
-			actions.emplace_back(std::move(action), *core);
+			actions.emplace_back(std::move(action), core);
 	}
 
 	shuffle_vector(actions); // shuffle action execution order to ensure fairness
 
 	for (auto& ele : actions) {
 		auto& action = ele.first;
-		Core& core = ele.second;
+		Core *core = ele.second;
 
-		if (!action->execute(&core))
+		if (!action->execute(core))
 			action = nullptr;
 	}
 
@@ -264,7 +264,7 @@ void Game::killWorstPlayerOnTimeout()
 	}
 }
 
-void Game::sendState(std::vector<std::pair<std::unique_ptr<Action>, Core &>> &actions, unsigned long long tick)
+void Game::sendState(std::vector<std::pair<std::unique_ptr<Action>, Core *>> &actions, unsigned long long tick)
 {
 	json state = encodeState(actions, tick);
 

--- a/src/game/StateEncoder.cpp
+++ b/src/game/StateEncoder.cpp
@@ -1,6 +1,6 @@
 #include "Game.h"
 
-json Game::encodeState(std::vector<std::pair<std::unique_ptr<Action>, Core &>> &actions, unsigned long long tick)
+json Game::encodeState(std::vector<std::pair<std::unique_ptr<Action>, Core *>> &actions, unsigned long long tick)
 {
 	json state;
 


### PR DESCRIPTION
Here's what was going on:

`std::vector<std::pair<std::unique_ptr<Action>, Core&>>` is what we store our actions in mid-game-tick.
Then we shuffle them to ensure fairness. We do this using `std::shuffle`. For pairs, this uses the following under the hood:
```cpp
std::swap(p1.first,  p2.first);   // swaps the unique_ptrs  — good
std::swap(p1.second, p2.second);  // swaps the Core& referents
```
Swapping the core references is what broke things.